### PR TITLE
Eslint disable comma-dangle rule from eslint and flow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
     node: true,
   },
   rules: {
+    'comma-dangle': OFF,
+    'flowtype/delimiter-dangle': OFF,
     'prettier/prettier': [
       ERROR,
       { singleQuote: true, trailingComma: 'all', jsxBracketSameLine: false },


### PR DESCRIPTION
this rule is stil applied through prettier. vscode eslint autofix is confused
when this rule is applied multiple times. It adds extra commas and they have to be
manually removed after