### PR TITLE
Feat: Added ConnectionCard component

### DIFF
--- a/flow-typed/npm/react-native-web_vx.x.x.js
+++ b/flow-typed/npm/react-native-web_vx.x.x.js
@@ -484,7 +484,7 @@ declare module 'react-native-web/dist/exports/ScrollView/index' {
     horizontal?: boolean,
     keyboardDismissMode?: 'none' | 'interactive' | 'on-drag',
     onContentSizeChange?: () => void,
-    onScroll: () => void,
+    onScroll?: () => void,
     pagingEnabled?: boolean,
     refreshControl?: React$Node,
     scrollEnabled?: boolean,

--- a/packages/components/index.js
+++ b/packages/components/index.js
@@ -19,3 +19,4 @@ export {
 } from './src/TimelineInformation';
 export { PlaceCard } from './src/PlaceCard';
 export { Shimmer } from './src/Shimmer';
+export { ConnectionCard } from './src/ConnectionCard';

--- a/packages/components/src/ConnectionCard/BadgesContainer.js
+++ b/packages/components/src/ConnectionCard/BadgesContainer.js
@@ -1,0 +1,36 @@
+// @flow
+
+import * as React from 'react';
+import { ScrollView } from 'react-native';
+import { Badge, StyleSheet } from '@kiwicom/universal-components';
+
+type BadgeWithId = { ...React.ElementProps<typeof Badge>, id: number };
+
+type Props = {|
+  +badges?: Array<BadgeWithId>,
+|};
+
+export default function BadgesContainer({ badges }: Props) {
+  if (badges == null) {
+    return null;
+  }
+  return (
+    <ScrollView horizontal style={styles.container}>
+      <>
+        {badges.map((badge, index) => (
+          <Badge key={badge.id} type={badge.type} style={styles.badge}>
+            {badge.children}
+          </Badge>
+        ))}
+      </>
+    </ScrollView>
+  );
+}
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  badge: {
+    marginEnd: 10,
+  },
+});

--- a/packages/components/src/ConnectionCard/ConnectionCard.js
+++ b/packages/components/src/ConnectionCard/ConnectionCard.js
@@ -1,0 +1,94 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { Badge, StyleSheet } from '@kiwicom/universal-components';
+// LocalizedPrice,
+
+import ConnectionCardRow from './ConnectionCardRow';
+import TripSector from './TripSector';
+import BadgesContainer from './BadgesContainer';
+
+type TripSectorWithId = {
+  ...React.ElementProps<typeof TripSector>,
+  id: number,
+};
+
+type Props = {|
+  +padding?: boolean,
+  +wayForth: Array<TripSectorWithId>,
+  +wayBack?: Array<TripSectorWithId>,
+  +duration?: string,
+  ...React.ElementProps<typeof BadgesContainer>,
+  // ...React.ElementProps<typeof LocalizedPrice>,
+|};
+
+type RenderTripSectorProps = {|
+  +way?: Array<TripSectorWithId>,
+|};
+
+const RenderTripSectors = ({ way }: RenderTripSectorProps) => {
+  if (way == null) {
+    return null;
+  }
+  return way.map(connection => (
+    <TripSector
+      key={connection.id}
+      arrival={connection.arrival}
+      arrivalTime={connection.arrivalTime}
+      carrier={connection.carrier}
+      tripDate={connection.tripDate}
+      departure={connection.departure}
+      departureTime={connection.departureTime}
+      duration={connection.duration}
+    />
+  ));
+};
+
+export default function ConnectionCard({
+  padding = true,
+  wayForth,
+  wayBack,
+  // localizedPrice,
+  duration,
+  badges,
+}: Props) {
+  const hasWayBack = wayBack && wayBack.length > 0;
+  return (
+    <View style={[styles.container, { paddingHorizontal: padding ? 10 : 0 }]}>
+      <ConnectionCardRow>
+        <RenderTripSectors way={wayForth} />
+      </ConnectionCardRow>
+      {hasWayBack && (
+        <React.Fragment>
+          {duration && (
+            <ConnectionCardRow>
+              <View style={styles.leftShift}>
+                <Badge type="neutral">Returns in {duration}</Badge>
+              </View>
+            </ConnectionCardRow>
+          )}
+          <ConnectionCardRow>
+            <RenderTripSectors way={wayBack} />
+          </ConnectionCardRow>
+        </React.Fragment>
+      )}
+      <ConnectionCardRow style={styles.lastRow}>
+        <BadgesContainer badges={badges} />
+        {/* <LocalizedPrice localizedPrice={localizedPrice} /> */}
+      </ConnectionCardRow>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  lastRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  leftShift: {
+    paddingStart: 103,
+  },
+});

--- a/packages/components/src/ConnectionCard/ConnectionCardRow.js
+++ b/packages/components/src/ConnectionCard/ConnectionCardRow.js
@@ -1,0 +1,21 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { StyleSheet, type StylePropType } from '@kiwicom/universal-components';
+
+type Props = {|
+  +children?: React.Node,
+  +style?: StylePropType,
+|};
+
+export default function ConnectionCardRow({ children, style }: Props) {
+  return <View style={[styles.container, style]}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 15,
+    paddingVertical: 5,
+  },
+});

--- a/packages/components/src/ConnectionCard/TripSector.js
+++ b/packages/components/src/ConnectionCard/TripSector.js
@@ -1,0 +1,150 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import {
+  Text,
+  StyleSheet,
+  CarrierLogo,
+  Icon,
+} from '@kiwicom/universal-components';
+
+type Props = {|
+  +arrival: string,
+  +arrivalTime: string,
+  +carrier: $ElementType<
+    $PropertyType<React.ElementProps<typeof CarrierLogo>, 'carriers'>,
+    number,
+  >,
+  +tripDate: string,
+  +departure: string,
+  +departureTime: string,
+  +duration: string,
+|};
+
+const TimelineArrow = () => (
+  <View style={styles.timelineArrowContainer}>
+    <View style={styles.circle} />
+    <View style={[styles.line, styles.firstLine]} />
+    <Icon
+      name="chevron-down"
+      color={defaultTokens.paletteInkLighter}
+      size="small"
+      style={styles.timelineArrowIcon}
+    />
+    <View style={[styles.line, styles.secondLine]} />
+    <View style={styles.circle} />
+  </View>
+);
+
+export default function TripSector({
+  arrival,
+  arrivalTime,
+  carrier,
+  departure,
+  departureTime,
+  duration,
+  tripDate,
+}: Props) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <View style={styles.carrierLogo}>
+          {/* <CarrierLogo size="medium" carriers={[carrier]} /> */}
+          <Text>CarrierLogo@TODO</Text>
+        </View>
+        <View style={styles.tripItems}>
+          <View style={styles.time}>
+            <Text numberOfLines={1}>{departureTime}</Text>
+            <Text numberOfLines={1}>{arrivalTime}</Text>
+          </View>
+          <TimelineArrow />
+          <View style={styles.places}>
+            <Text style={styles.text} numberOfLines={1}>
+              {departure}
+            </Text>
+            <Text style={styles.text} numberOfLines={1}>
+              {arrival}
+            </Text>
+          </View>
+          <View style={styles.infoItems}>
+            <Text style={[styles.text, styles.info]} numberOfLines={1}>
+              {tripDate}
+            </Text>
+            <Text style={[styles.text, styles.info]} numberOfLines={1}>
+              {duration}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: 70,
+  },
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 0,
+  },
+  carrierLogo: {
+    width: 30,
+  },
+  tripItems: {
+    flexDirection: 'row',
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 5,
+  },
+  time: {
+    width: 60,
+    fontWeight: 'bold',
+    fontSize: parseFloat(defaultTokens.fontSizeTextNormal),
+    lineHeight: 19,
+    paddingHorizontal: 10,
+  },
+  places: {
+    flex: 1,
+  },
+  text: {
+    fontSize: parseFloat(defaultTokens.fontSizeTextSmall),
+    lineHeight: 17,
+    paddingHorizontal: 5,
+    paddingVertical: 5,
+  },
+  infoItems: {
+    alignItems: 'flex-end',
+  },
+  info: {
+    color: defaultTokens.colorTextSecondary,
+  },
+  timelineArrowContainer: {
+    minHeight: 35,
+    alignItems: 'center',
+  },
+  circle: {
+    borderRadius: parseFloat(defaultTokens.borderRadiusCircle),
+    width: 6,
+    height: 6,
+    backgroundColor: defaultTokens.paletteInkLighter,
+  },
+  line: {
+    flex: 1,
+    backgroundColor: defaultTokens.paletteCloudNormal,
+    width: 2,
+  },
+  firstLine: {
+    marginBottom: -5,
+  },
+  secondLine: {
+    marginTop: -3,
+  },
+  timelineArrowIcon: {
+    fontWeight: 'bold',
+  },
+});

--- a/packages/components/src/ConnectionCard/__tests__/ConnectionCard.test.js
+++ b/packages/components/src/ConnectionCard/__tests__/ConnectionCard.test.js
@@ -1,0 +1,70 @@
+// @flow
+
+import * as React from 'react';
+import { render } from 'react-native-testing-library';
+import { Badge } from '@kiwicom/universal-components';
+
+import ConnectionCard from '../ConnectionCard';
+import BadgesContainer from '../BadgesContainer';
+import TripSector from '../TripSector';
+
+describe('ConnectionCard', () => {
+  const badges = [
+    {
+      id: 1,
+      type: 'warning',
+      children: 'Cheapest',
+    },
+    {
+      id: 2,
+      type: 'info',
+      children: 'WiFi',
+    },
+  ];
+  const wayForth = [
+    {
+      id: 1,
+      arrival: 'Berlin TXL',
+      arrivalTime: '14:20',
+      carrier: { code: 'OK', name: 'Czech Airlines' },
+      tripDate: 'Mon 22 Oct',
+      departure: 'Prague PRG',
+      departureTime: '13:20',
+      duration: '1h',
+    },
+    {
+      id: 2,
+      arrival: 'Moscow VKO',
+      arrivalTime: '20:20',
+      carrier: { code: 'FR', type: 'airline', name: 'Ryanair' },
+      tripDate: 'Mon 22 Oct',
+      departure: 'Berlin TXL',
+      departureTime: '15:20',
+      duration: '3h',
+    },
+  ];
+  // const localizedPrice = '€123,455.35';
+  const { getAllByType, getByType } = render(
+    <ConnectionCard
+      // localizedPrice={localizedPrice}
+      wayForth={wayForth}
+      badges={badges}
+    />,
+  );
+  // @TODO in this environment, I get 'No instances found' when it was working in @kiwicom/universal-components; could be linked to not having the latest version of the npm package or because the Badges are returned as an array?
+  xit('should contain correct number of badges', () => {
+    expect(getAllByType(Badge)).toHaveLength(1);
+  });
+  it('should contain correct number of badges container', () => {
+    expect(getAllByType(BadgesContainer)).toHaveLength(1);
+  });
+  it('should contain correct number of connections', () => {
+    expect(getAllByType(TripSector)).toHaveLength(2);
+  });
+
+  // it('should set proper price format', () => {
+  //   expect(getByType(LocalizedPrice).findByType(Text).props.children).toBe(
+  //     '€123,455.35',
+  //   );
+  // });
+});

--- a/packages/components/src/ConnectionCard/index.js
+++ b/packages/components/src/ConnectionCard/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export { default as ConnectionCard } from './ConnectionCard';


### PR DESCRIPTION
Summary:
TODO Inquire why one of the tests for ConnectionCard fails in this environment and worked fine in @kiwicom/universal-components;
LocalizedPrice is not available in @kiwicom/universal-components@0.0.6

=> This must be revisited once we publish v0.0.8 of @kiwicom/universal-components

This is how it can be used:
```
const hasReturnConnection = true;
    const hasBadges = true;
    // const localizedPrice = '$455.3455';
    return (
      <ConnectionCard
        wayForth={[
          {
            id: 1,
            arrival: 'Berlin TXL',
            arrivalTime: '14:20',
            carrier: { code: 'OK', name: 'Czech Airlines' },
            tripDate: 'Mon 22 Oct',
            departure: 'Prague PRG',
            departureTime: '13:20',
            duration: '1h',
          },
          {
            id: 2,
            arrival: 'Moscow VKO',
            arrivalTime: '20:20',
            carrier: { code: 'FR', type: 'airline', name: 'Ryanair' },
            tripDate: 'Mon 22 Oct',
            departure: 'Berlin TXL',
            departureTime: '15:20',
            duration: '3h',
          },
        ]}
        wayBack={
          hasReturnConnection && [
            {
              id: 1,
              arrival: 'Prague PRG',
              arrivalTime: '14:00',
              carrier: { code: 'TO', name: 'Transavia France' },
              tripDate: 'Mon 25 Oct',
              departure: 'Moscow VKO',
              departureTime: '10:00',
              duration: '4h',
            },
          ]
        }
        duration={hasReturnConnection && '3 days'}
        {/* localizedPrice={localizedPrice} */}
        badges={
          hasBadges && [
            {
              id: 1,
              type: 'warning',
              children: 'Cheapest',
            },
            {
              id: 2,
              type: 'neutral',
              children: 'Wi-fi',
            },
          ]
        }
      />
    );
```