### PR TITLE
Chore: Upgraded @kiwicom/universal-components to v0.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # next.js
 #
 .next/
+apps/web/static/fonts/*
 
 # node.js
 #

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@kiwicom/orbit-design-tokens": "^0.2.5",
-    "@kiwicom/universal-components": "^0.0.6",
+    "@kiwicom/universal-components": "0.0.8",
     "@kiwicom/margarita-navigation": "^0.0.0"
   },
   "devDependencies": {}

--- a/apps/core/scenes/search/Search.js
+++ b/apps/core/scenes/search/Search.js
@@ -170,18 +170,16 @@ class Search extends React.Component<Props, State> {
               leftIcon={<Icon name={TRIP_TYPE[tripType].icon} />}
               rightIcon={<Icon name="show-more" />}
               onPress={this.handleTripTypePress}
-            >
-              {TRIP_TYPE[tripType].label}
-            </Button>
+              label={TRIP_TYPE[tripType].label}
+            />
             <Button
               type="secondary"
               width={120}
               leftIcon={<Icon name="passengers" />}
               rightIcon={<Icon name="baggage-set" />}
               onPress={this.handlePassengersPress}
-            >
-              {`${adults + infants} | ${bags}`}
-            </Button>
+              label={`${adults + infants} | ${bags}`}
+            />
           </View>
           <TripInput
             onPress={this.todo}
@@ -204,8 +202,8 @@ class Search extends React.Component<Props, State> {
             onChangeText={this.handleDateToChange}
             value={dateTo}
           />
-          <Button onPress={this.handleSubmitPress}>Search</Button>
-          <Button onPress={this.goToPlacePicker}>PlacePicker</Button>
+          <Button onPress={this.handleSubmitPress} label="Search" />
+          <Button onPress={this.goToPlacePicker} label="PlacePicker" />
         </View>
         <Modal
           visible={modalType !== MODAL_TYPE.HIDDEN}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -29,6 +29,19 @@ module.exports = withTM({
       '.js',
     ];
 
+    config.module.rules.push({
+      test: /\.(woff|woff2|eot|ttf|otf)$/,
+      use: [
+        {
+          loader: 'file-loader',
+          options: {
+            outputPath: '../../static/fonts/',
+            name: '[name].[ext]',
+          },
+        },
+      ],
+    });
+
     return config;
   },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@kiwicom/margarita-core": "^0",
     "@kiwicom/margarita-relay": "^0",
+    "file-loader": "^3.0.1",
     "next": "^7.0.2",
     "next-plugin-transpile-modules": "^0.1.3",
     "react": "^16.6.3",

--- a/apps/web/pages/_document.js
+++ b/apps/web/pages/_document.js
@@ -3,6 +3,7 @@
 import Document, { Head, Main, NextScript } from 'next/document';
 import * as React from 'react';
 import { AppRegistry } from 'react-native-web';
+import OrbitIconFont from '@kiwicom/universal-components/lib/fonts/orbit-icons.ttf';
 
 // Force Next-generated DOM elements to fill their parent's height
 const normalizeNextElements = `
@@ -12,6 +13,17 @@ const normalizeNextElements = `
     height: 100%;
   }
 `;
+
+// This is a workaround for the following bug:
+// https://github.com/zeit/next.js/issues/3520
+const globalStyle = {
+  __html: `
+  @font-face {
+    font-family: 'orbit-icons';
+    src: url(${OrbitIconFont});
+  }
+`,
+};
 
 export default class MyDocument extends Document {
   static getInitialProps({ renderPage }: (cb: Function) => void) {
@@ -37,6 +49,7 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700"
             rel="stylesheet"
           />
+          <style dangerouslySetInnerHTML={globalStyle} />
         </Head>
         <body style={{ height: '100%', overflow: 'hidden' }}>
           <Main />

--- a/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
+++ b/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
@@ -30,10 +30,14 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
         },
         Object {
           "fontSize": 16,
+          "height": 16,
+          "lineHeight": 16,
+          "width": 16,
         },
         Object {
           "color": "orange",
         },
+        undefined,
       ]
     }
   >
@@ -47,6 +51,7 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
     }
   >
     <Text
+      numberOfLines={1}
       style={
         Array [
           Object {

--- a/packages/components/src/passengersInputs/PassengersInputs.js
+++ b/packages/components/src/passengersInputs/PassengersInputs.js
@@ -86,14 +86,14 @@ class PassengersInputs extends React.Component<Props, State> {
         />
         <View style={styles.bottomButtons}>
           <View style={styles.buttonWrapper}>
-            <Button onPress={onClosePress} type="secondary">
-              Close
-            </Button>
+            <Button onPress={onClosePress} type="secondary" label="Close" />
           </View>
           <View style={styles.buttonWrapper}>
-            <Button onPress={this.handleSavePress} type="primary">
-              Save
-            </Button>
+            <Button
+              onPress={this.handleSavePress}
+              type="primary"
+              label="Save"
+            />
           </View>
         </View>
       </View>

--- a/packages/components/src/passengersInputs/__tests__/__snapshots__/PassengersInputs.test.js.snap
+++ b/packages/components/src/passengersInputs/__tests__/__snapshots__/PassengersInputs.test.js.snap
@@ -74,11 +74,10 @@ Object {
         }
       >
         <Button
+          label="Close"
           onPress={[MockFunction]}
           type="secondary"
-        >
-          Close
-        </Button>
+        />
       </Component>
       <Component
         style={
@@ -89,11 +88,10 @@ Object {
         }
       >
         <Button
+          label="Save"
           onPress={[Function]}
           type="primary"
-        >
-          Save
-        </Button>
+        />
       </Component>
     </Component>
   </Component>,

--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -44,9 +44,7 @@ const Select = ({
     <>
       {options}
       <View style={styles.buttonWrapper}>
-        <Button onPress={onClosePress} type="secondary">
-          Close
-        </Button>
+        <Button onPress={onClosePress} type="secondary" label="Close" />
       </View>
     </>
   );

--- a/packages/components/src/select/SelectOption.js
+++ b/packages/components/src/select/SelectOption.js
@@ -64,6 +64,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingEnd: parseInt(defaultTokens.paddingButtonNormal, 10),
     alignItems: 'center',
+    justifyContent: 'space-between',
   },
   radioUnderline: {
     borderBottomColor: defaultTokens.paletteInkLighter,

--- a/packages/components/src/select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/select/__tests__/__snapshots__/Select.test.js.snap
@@ -27,11 +27,10 @@ Object {
       }
     >
       <Button
+        label="Close"
         onPress={[MockFunction]}
         type="secondary"
-      >
-        Close
-      </Button>
+      />
     </Component>
   </React.Fragment>,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,13 +1067,6 @@
   dependencies:
     graphql-relay "^0.5.5"
 
-"@kiwicom/orbit-components@^0.23.0":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-components/-/orbit-components-0.23.1.tgz#164fb8bb3a13bd9277429d8e8f2775d3116eee67"
-  integrity sha512-e4jdXgn5VZ7RSoCYB8KyUSOKukZYx59PtyorflyAT/OVN/vG5ShtXwcMcf6+UC/PzU0JTLGURFVXS97XkWfGeA==
-  dependencies:
-    "@kiwicom/orbit-design-tokens" "^0.2.5"
-
 "@kiwicom/orbit-design-tokens@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@kiwicom/orbit-design-tokens/-/orbit-design-tokens-0.2.5.tgz#b945e5f792d321aa66ef23bc327000e4ff702e50"
@@ -1081,12 +1074,11 @@
   dependencies:
     ramda "^0.25.0"
 
-"@kiwicom/universal-components@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@kiwicom/universal-components/-/universal-components-0.0.6.tgz#09f3c1561ce0e5f812ded0537c75ff7ace27c790"
-  integrity sha512-F0/68tHN8zKZmSh/k3fDePNFh9wb4NUi6ZODdIgSVW9A3XOinGCKdqkijADlJrekoFL7U/nSGpcvwM29JXBp6g==
+"@kiwicom/universal-components@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@kiwicom/universal-components/-/universal-components-0.0.8.tgz#aca69fa51aea9edc6b6787a04fba66577c3b6dce"
+  integrity sha512-0diFRam8pNUtQJUpNZ3ZehAD+aJEguvAOIloaYsaTdCyQUUUJ87KM0TBCS0iisBhRd8+hgL7UH8KZsCj/B73RQ==
   dependencies:
-    "@kiwicom/orbit-components" "^0.23.0"
     "@kiwicom/orbit-design-tokens" "^0.2.5"
     react-native-status-bar-height "^2.2.0"
     styled-components "^4.1.2"
@@ -5197,6 +5189,14 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file-loader@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-3.0.1.tgz#f8e0ba0b599918b51adfe45d66d1e771ad560faa"
+  integrity sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==
+  dependencies:
+    loader-utils "^1.0.2"
+    schema-utils "^1.0.0"
 
 filename-regex@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Summary: I had to modify the webpack config for the Nextjs application to load the orbit-icons.ttf file. Basically, it copies the font files over to apps/web/static/fonts and they are then accessible; appending a style tag in _document.js makes the Icon component from '@kiwicom/universal-components' work without adding any CSS file.
I had to take into account some breaking changes for Button and RadioButton component: label prop is preferred if there is no need for styling; children prop is used for specific components and/or Text component with diffeerent styling.