### PR TITLE
Chore: update @kiwicom/graphql-utils to v0.3.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     node: true,
   },
   rules: {
+    'no-unused-vars': ERROR,
     'no-restricted-imports': [
       ERROR,
       {

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
     "@kiwicom/graphql-global-id": "^0.4.0",
-    "@kiwicom/graphql-utils": "^0.1.0",
+    "@kiwicom/graphql-utils": "^0.3.0",
     "@mrtnzlml/fetch": "^1.3.0",
     "apollo-server": "^2.2.6",
     "buffer": "^5.2.1",

--- a/apps/graphql/src/Schema.js
+++ b/apps/graphql/src/Schema.js
@@ -1,7 +1,6 @@
 // @flow
 
-import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
-import GlobalID from '@kiwicom/graphql-global-id';
+import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 
 import Itineraries from './queries/Itineraries';
 import Locations from './queries/Locations';

--- a/apps/graphql/src/dataloaders/Itinerariesloader.js
+++ b/apps/graphql/src/dataloaders/Itinerariesloader.js
@@ -1,9 +1,9 @@
 // @flow
 
-import Dataloader from 'dataloader';
 import stringify from 'json-stable-stringify';
 import qs from 'querystring';
 import { DateTime } from 'luxon';
+import { OptimisticDataloader } from '@kiwicom/graphql-utils';
 
 import fetch from '../services/Fetch';
 
@@ -100,10 +100,10 @@ const sanitizeIteneraries = (
 };
 
 export default (apikey: string) =>
-  new Dataloader<ItinerariesSearchParameters, Itineraries[]>(
+  new OptimisticDataloader(
     async (
       keys: $ReadOnlyArray<ItinerariesSearchParameters>,
-    ): Promise<Array<Itineraries[]>> => fetchItineraries(keys, apikey),
+    ): Promise<Array<Itineraries[] | Error>> => fetchItineraries(keys, apikey),
     {
       cacheKeyFn: stringify,
     },

--- a/apps/graphql/src/dataloaders/Locationsloader.js
+++ b/apps/graphql/src/dataloaders/Locationsloader.js
@@ -1,8 +1,8 @@
 // @flow
 
-import Dataloader from 'dataloader';
 import stringify from 'json-stable-stringify';
 import qs from 'querystring';
+import { OptimisticDataloader } from '@kiwicom/graphql-utils';
 
 import fetch from '../services/Fetch';
 
@@ -43,9 +43,10 @@ const fetchLocations = async (
 };
 
 export default (apikey: string) =>
-  new Dataloader<{| +term: string |}, Locations>(
-    async (ids: $ReadOnlyArray<{| +term: string |}>) =>
-      fetchLocations(ids, apikey),
+  new OptimisticDataloader(
+    async (
+      ids: $ReadOnlyArray<{| +term: string |}>,
+    ): Promise<Array<Location[] | Error>> => fetchLocations(ids, apikey),
     {
       cacheKeyFn: stringify,
     },

--- a/packages/components/src/ConnectionCard/__tests__/ConnectionCard.test.js
+++ b/packages/components/src/ConnectionCard/__tests__/ConnectionCard.test.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { render } from 'react-native-testing-library';
-import { Badge } from '@kiwicom/universal-components';
+// import { Badge } from '@kiwicom/universal-components';
 
 import ConnectionCard from '../ConnectionCard';
 import BadgesContainer from '../BadgesContainer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,11 +1065,12 @@
   dependencies:
     "@mrtnzlml/utils" "^1.0.2"
 
-"@kiwicom/graphql-utils@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/graphql-utils/-/graphql-utils-0.1.0.tgz#966777d8f05184d34c3d5802ed27a8f4938159f5"
-  integrity sha512-AMg1GQ/q9k2a8/oZ8FHu2rTOru6boPKJ2hzWuhfGelx3CKp1rFXRArGKrIDestpnX56j+kPn2NELuX+2uI8wCw==
+"@kiwicom/graphql-utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@kiwicom/graphql-utils/-/graphql-utils-0.3.0.tgz#042e7be6047b622c2e9fe1d4641c8117686ee8cb"
+  integrity sha512-hzLLRme8FI5FaORgvRffhkGpQGh4G04TkwlKe4QOOG+rHztAd87YF5ijRuZ+qhJ7Iac37vmWlGcBl+pP9oI5VQ==
   dependencies:
+    dataloader "^1.4.0"
     graphql-relay "^0.5.5"
 
 "@kiwicom/orbit-design-tokens@^0.2.5":


### PR DESCRIPTION
Used OptimisticDataloader from @kiwicom/graphql-utils
Original data-loader kills load batch if one of this response values is
Error instance. This optimistic data-loader keeps Error value as a valid
response. This means that it's possible to return as many responses
as possible and convert Errors to the error messages in the response
if necessary.

 @see https://github.com/facebook/dataloader/issues/41