### PR TITLE
Fix: Changed fetch url

### DIFF
--- a/apps/graphql/src/services/Fetch.js
+++ b/apps/graphql/src/services/Fetch.js
@@ -50,7 +50,7 @@ export default async function fetch(
   }
 
   try {
-    const response = await fetchWithRetries(`${BASE_URL}${'/dsdas'}`, {
+    const response = await fetchWithRetries(`${BASE_URL}${url}`, {
       fetchTimeout: 30000,
       retryDelays: [1000, 3000],
       ...prepareOptions(options, apikey),


### PR DESCRIPTION
Summary: Fetch is currently failing in master because of url change from `Logger` implementation.
Changed back to original value.