### PR TITLE
Chore: Deployed Margarita's graphql and web apps on Netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,17 @@
 #
 .next/
 apps/web/static/fonts/*
+apps/web/out/
 
 # node.js
 #
 node_modules/
 npm-debug.log
 yarn-error.log
+
+# apps/graphql
+#
+apps/graphql/netlify
 
 .env
 

--- a/apps/graphql/.babelrc
+++ b/apps/graphql/.babelrc
@@ -1,4 +1,11 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-flow"],
-  "plugins": ["@babel/plugin-proposal-nullish-coalescing-operator"]
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-flow"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime",
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator"
+  ]
 }

--- a/apps/graphql/index.js
+++ b/apps/graphql/index.js
@@ -1,5 +1,3 @@
 // @flow
 
-import schema from './src/Schema';
-
-export { schema };
+export { default as schema } from './src/Schema';

--- a/apps/graphql/lambda/graphql.js
+++ b/apps/graphql/lambda/graphql.js
@@ -1,0 +1,22 @@
+// @flow
+
+import { ApolloServer } from 'apollo-server-lambda';
+
+import createContext from '../src/services/GraphQLContext';
+import schema from '../src/Schema';
+
+const server = new ApolloServer({
+  schema,
+  context: () => {
+    // Please note: this context must be created for every single request.
+    // This is important because of these reasons:
+    //   - tokens and user identities are per request
+    //   - dataloaders use Map internally (not LRU) and they would otherwise
+    //     grow indefinitely because the Map content is not garbage collected
+    return createContext();
+  },
+  playground: true,
+  introspection: true,
+});
+
+exports.handler = server.createHandler();

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -9,6 +9,7 @@
     "@kiwicom/graphql-utils": "^0.3.0",
     "@mrtnzlml/fetch": "^1.3.0",
     "apollo-server": "^2.2.6",
+    "apollo-server-lambda": "^2.3.1",
     "buffer": "^5.2.1",
     "chalk": "^2.4.2",
     "dataloader": "^1.4.0",
@@ -20,8 +21,11 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.2.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",
+    "apollo-server-lambda": "^2.3.1",
     "nodemon": "^1.18.7"
   },
   "scripts": {
@@ -29,7 +33,7 @@
   },
   "betterScripts": {
     "start": {
-      "command": "nodemon -x babel-node server.js"
+      "command": "nodemon -x babel-node src/server.js"
     }
   }
 }

--- a/apps/graphql/src/server.js
+++ b/apps/graphql/src/server.js
@@ -4,9 +4,9 @@ import '@babel/polyfill';
 
 import { ApolloServer } from 'apollo-server';
 
-import createContext from './src/services/GraphQLContext';
-import schema from './src/Schema';
-import Logger from './src/services/Logger';
+import createContext from './services/GraphQLContext';
+import schema from './Schema';
+import Logger from './services/Logger';
 
 const server = new ApolloServer({
   schema,

--- a/apps/graphql/src/services/TestingTools.js
+++ b/apps/graphql/src/services/TestingTools.js
@@ -2,7 +2,7 @@
 
 import { graphql as originalGraphQL } from 'graphql';
 
-import { schema } from '../..';
+import schema from '../Schema';
 import createContext from './GraphQLContext';
 
 jest.mock('./Fetch.js');

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
+    "export": "next export",
     "analyze": "better-npm-run analyze"
   },
   "betterScripts": {
@@ -35,6 +36,7 @@
     "@babel/preset-flow": "^7.0.0",
     "babel-plugin-jsx-remove-data-test-id": "^1.2.1",
     "babel-plugin-react-native-web": "^0.9.9",
+    "babel-plugin-relay": "^1.7.0",
     "webpack": "^4.26.1",
     "webpack-bundle-analyzer": "^3.0.3"
   }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  publish = "apps/web/out"
+  command = "echo GRAPHQL_URL=$GRAPHQL_URL > .env; yarn build && yarn export && yarn netlify-lambda:build"
+  functions = "apps/graphql/netlify"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "web": "yarn workspace @kiwicom/margarita-web dev",
     "dev": "yarn concurrently \"yarn web\" \" yarn server\" ",
     "build": "yarn workspace @kiwicom/margarita-web build",
+    "netlify-lambda:build": "netlify-lambda build apps/graphql/lambda",
+    "netlify-lambda:serve": "netlify-lambda serve apps/graphql/lambda",
     "start": "yarn workspace @kiwicom/margarita-web start",
+    "export": "yarn workspace @kiwicom/margarita-web export",
     "analyze": "yarn workspace @kiwicom/margarita-web analyze",
     "relay": "yarn babel-node --config=babel.config.js scripts/relay-compiler.js",
     "lint": "eslint . --report-unused-disable-directives",
@@ -50,6 +53,7 @@
     "jest": "^23.6.0",
     "jest-expo": "^32.0.0",
     "jest-fetch-mock": "^2.0.1",
+    "netlify-lambda": "^1.2.0",
     "react-native-testing-library": "^1.4.2",
     "react-test-renderer": "^16.6.3",
     "relay-compiler": "^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,7 +729,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     resolve "^1.8.1"
 
-"@babel/plugin-transform-runtime@^7.0.0":
+"@babel/plugin-transform-runtime@^7.0.0", "@babel/plugin-transform-runtime@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
   integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
@@ -848,7 +848,7 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
-"@babel/preset-env@^7.2.0":
+"@babel/preset-env@^7.0.0", "@babel/preset-env@^7.2.0":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.2.3.tgz#948c8df4d4609c99c7e0130169f052ea6a7a8933"
   integrity sha512-AuHzW7a9rbv5WXmvGaPX7wADxFkZIqKlbBh1dmZUQp4iwiPpkE/Qnrji6SC4UQCQzvWY/cpHET29eUhXS9cLPw==
@@ -1925,6 +1925,16 @@ apollo-server-express@2.3.1:
     graphql-tools "^4.0.0"
     type-is "^1.6.16"
 
+apollo-server-lambda@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-lambda/-/apollo-server-lambda-2.3.1.tgz#187d2d635aec981ea8956d75af76c185419abd61"
+  integrity sha512-wWDzn2tG3e6ygZLdYXAv+WR80aRbMbOwXaQ7Jw1vMW08ltpvL/FTJb6Hf7oUlINKwZ67uqm3BbeSS5o4jMM12A==
+  dependencies:
+    "@apollographql/graphql-playground-html" "^1.6.6"
+    apollo-server-core "2.3.1"
+    apollo-server-env "2.2.0"
+    graphql-tools "^4.0.0"
+
 apollo-server-plugin-base@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.2.1.tgz#d08c9576f7f11ab6e212f352d482faaa4059a31e"
@@ -2358,6 +2368,16 @@ babel-loader@8.0.2:
   integrity sha512-Law0PGtRV1JL8Y9Wpzc0d6EE0GD7LzXWCfaeWwboUMcBWNG6gvaWTK1/+BK7a4X5EmeJiGEuDDFxUsOa8RSWCw==
   dependencies:
     find-cache-dir "^1.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    util.promisify "^1.0.0"
+
+babel-loader@^8.0.0:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.5.tgz#225322d7509c2157655840bba52e46b6c2f2fe33"
+  integrity sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==
+  dependencies:
+    find-cache-dir "^2.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
@@ -3509,7 +3529,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.18.0, commander@^2.8.1, commander@^2.9.0:
+commander@^2.11.0, commander@^2.17.1, commander@^2.18.0, commander@^2.8.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -5047,6 +5067,13 @@ expo@^31.0.6:
     serialize-error "^2.1.0"
     uuid-js "^0.7.5"
     whatwg-fetch "^2.0.4"
+
+express-logging@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/express-logging/-/express-logging-1.1.1.tgz#62839618cbab5bb3610f1a1c1485352fe9d26c2a"
+  integrity sha1-YoOWGMurW7NhDxocFIU1L+nSbCo=
+  dependencies:
+    on-headers "^1.0.0"
 
 express@^4.0.0, express@^4.16.3:
   version "4.16.4"
@@ -7239,6 +7266,11 @@ junk@^1.0.1:
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
   integrity sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 kind-of@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
@@ -8174,6 +8206,26 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
 
+netlify-lambda@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/netlify-lambda/-/netlify-lambda-1.2.0.tgz#8e9bf370c81e2b4e335442ccf67ff2583df34c48"
+  integrity sha512-hYbh/niRAB9347Ix7flWdtzfMvq0vyOOB2003Xt/UfV5+SSyzSM8Pksj+KIk3HMwc2zkj9W3P0EKv6nS3ie15w==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-transform-object-assign" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    babel-loader "^8.0.0"
+    body-parser "^1.18.3"
+    commander "^2.17.1"
+    express "^4.16.3"
+    express-logging "^1.1.1"
+    jwt-decode "^2.2.0"
+    toml "^2.3.3"
+    webpack "^4.17.1"
+    webpack-merge "^4.1.4"
+
 next-plugin-transpile-modules@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/next-plugin-transpile-modules/-/next-plugin-transpile-modules-0.1.3.tgz#13aec6c1c9467aa467693837cd2921ca6b6fb797"
@@ -8531,7 +8583,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.1:
+on-headers@^1.0.0, on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
   integrity sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=
@@ -10997,6 +11049,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toml@^2.3.3:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.5.tgz#a1f5d7f7efd300fa426258f3e74374536191e3db"
+  integrity sha512-ulY/Z2yPWKl/3JvGJvnEe7mXqVt2+TtDoRxJNgTAwO+3lwXefeCHS697NN0KRy6q7U/b1MnSnj/UGF/4U0U2WQ==
+
 touch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
@@ -11465,6 +11522,13 @@ webpack-merge@^4.1.0:
   dependencies:
     lodash "^4.17.5"
 
+webpack-merge@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
+  integrity sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==
+  dependencies:
+    lodash "^4.17.5"
+
 webpack-sources@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.2.0.tgz#18181e0d013fce096faf6f8e6d41eeffffdceac2"
@@ -11508,6 +11572,36 @@ webpack@4.20.2:
     schema-utils "^0.4.4"
     tapable "^1.1.0"
     uglifyjs-webpack-plugin "^1.2.4"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@^4.17.1:
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.28.4.tgz#1ddae6c89887d7efb752adf0c3cd32b9b07eacd0"
+  integrity sha512-NxjD61WsK/a3JIdwWjtIpimmvE6UrRi3yG54/74Hk9rwNj5FPkA4DJCf1z4ByDWLkvZhTZE+P3C/eh6UD5lDcw==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/wasm-edit" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
 


### PR DESCRIPTION
Summary: After this PR is merged, Netlify will build both apps whenever a change occurs on the master branch.

apps/graphql/lambda is the folder that will be built by Netlify; so right now, only graphql.js would be built. Once build is successful, the Netlify Function is available at /.netlify/functions/<name_of_file> if <name_of_file>.js is in apps/graphql/lambda.

It will also deploy the static site from NextJs, which is built into 'apps/web/out'.

Because we are using `react-native-dotenv` in @kiwicom/margarita-relay, we need to explicitly create a .env file from the environment variables (which are already added to Netlify Deploy Settings); hence the 'echo GRAPHQL_URL=$GRAPHQL_URL > .env;' inside netlify.toml. That means we will need to be mindful of when we use more environment variables from import calls with `react-native-dotenv`.

This netlify.toml file is necessary to tell Netlify which build command to execute, and where to look for built versions of Netlify Functions. In our build command, there is 'yarn netlify-lambda:build', which stands for 'netlify-lambda build apps/graphql/lambda'. That build will compile everything from 'apps/graphql/lambda' into 'apps/graphql/netlify'.