### PR TITLE
Chore: added --frozen-lockfile to yarn command in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
-      - run: yarn install
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-
+      - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
"yarn install" can change the yarn.lock file, but we don't want this behavior in the CI