### PR TITLE
Chore: CircleCI autodeploys GraphQL server to AWS Lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,64 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run: yarn test-ci
-
+  build-graphql:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/margarita
+    steps:
+      - checkout
+      - retore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-
+      - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+      - run:
+          name: Build GraphQL lambda
+          command: yarn build:graphql
+  deploy-graphql:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/margarita
+    steps:
+      - checkout
+      - retore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-
+      - run:
+        name: Install Serverless CLI and dependencies
+        command: |
+          sudo npm i -g serverless
+          yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+      - run:
+          name: Deploy Application
+          command: yarn deploy:graphql
 workflows:
   version: 2
   test-and-release:
     jobs:
       - test
+  build-and-deploy-graphql:
+    jobs:
+      - test:
+          filters:
+            branches:
+              only: master
+      - build-graphql:
+          filters:
+            branches:
+              only: master
+      - deploy-graphql:
+          requires:
+            - build-graphql
+          filters:
+            branches:
+              only: master

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log
 #
 apps/graphql/lambda/dist
 apps/graphql/lambda/.serverless
+apps/graphql/.serverless
 
 .env
 

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -39,7 +39,8 @@
   },
   "scripts": {
     "start": "better-npm-run start",
-    "build": "yarn webpack"
+    "build": "yarn webpack",
+    "deploy": "serverless deploy --conceal"
   },
   "betterScripts": {
     "start": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test": "node node_modules/jest/bin/jest.js --config=.jest.json",
     "test-ci": "yarn flow && yarn lint && yarn test --ci --color --maxWorkers=2",
     "server": "yarn workspace @kiwicom/margarita-graphql start",
+    "build:graphql": "yarn workspace @kiwicom/margarita-graphql build",
+    "deploy:graphql": "yarn workspace @kiwicom/margarita-graphql deploy",
     "postinstall": "yarn workspace @kiwicom/margarita-mobile postinstall"
   },
   "private": true,


### PR DESCRIPTION
Summary: Netlify functions were not enough for us, so CircleCI should now deploy our GraphQL server to AWS Lambda when we merge into master.