### PR TITLE
Fix: json-loader removed for GraphQL build to go smoothly

### DIFF
--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -30,7 +30,6 @@
     "babel-loader": "^8.0.5",
     "bufferutil": "^4.0.1",
     "flow-aws-lambda": "https://github.com/yarax/flow-aws-lambda#407f59f87889345a77b642fbeac91ff5f89865a1",
-    "json-loader": "^0.5.7",
     "nodemon": "^1.18.7",
     "uglifyjs-webpack-plugin": "^2.1.1",
     "utf-8-validate": "^5.0.2",

--- a/apps/graphql/webpack.config.js
+++ b/apps/graphql/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.json$/, exclude: /node_modules/, loader: 'json-loader' },
       {
         // see: https://github.com/apollographql/react-apollo/issues/1737
         test: /\.mjs$/,


### PR DESCRIPTION
Summary: Adding AllBookings.json somehow broke the GraphQL build and removing json-loader helped for the build to complete.