### PR TITLE
Fix: (Partial) Hydrate props from query params

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@
 **/datasets/**
 **/__generated__/**
 apps/graphql/lambda/dist
+apps/web/out
+apps/web/.next

--- a/apps/web/components/withPageRouter.js
+++ b/apps/web/components/withPageRouter.js
@@ -1,0 +1,24 @@
+// @flow
+
+import * as React from 'react';
+import { withRouter, type Router } from 'next/router';
+
+export const withPageRouter = <T>(
+  Component: React.ComponentType<T & { router: Router }>,
+): Class<React.Component<T>> => {
+  return withRouter<T>(({ router, ...props }) => {
+    // split at first `?`
+    const searchParams = new URLSearchParams(router.asPath.split(/\?/)[1]);
+
+    const query = {};
+    for (const [key, value] of searchParams) {
+      query[key] = value;
+    }
+
+    // replace the empty query
+    // $FlowFixMe flow-typed Router has read-only on query
+    router.query = query;
+
+    return <Component {...props} router={router} />;
+  });
+};

--- a/apps/web/pages/results.js
+++ b/apps/web/pages/results.js
@@ -3,9 +3,9 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { Results } from '@kiwicom/margarita-core';
-import { withRouter } from 'next/router';
 import { StyleSheet } from '@kiwicom/universal-components';
 
+import { withPageRouter } from '../components/withPageRouter';
 import Layout from '../components/Layout';
 
 const results = ({ router }) => {
@@ -23,4 +23,4 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
-export default withRouter<React.Element<any>>(results);
+export default withPageRouter<React.Element<any>>(results);

--- a/packages/components/src/SearchParamsSummary/SearchParamsSummary.js
+++ b/packages/components/src/SearchParamsSummary/SearchParamsSummary.js
@@ -50,30 +50,30 @@ export default function SearchParamsSummary({
           <Icon name={icon} />
           <Text style={styles.arrivalCity}>{arrival?.city || ''}</Text>
         </View>
-        {tripType === 'OneWay' ? (
-          <View>
+        <View style={styles.row}>
+          {tripType === 'OneWay' ? (
             <AdaptableBadge
               style={styles.badge}
               textStyle={styles.badgeText}
               text={departure?.localizedDate ?? ''}
             />
-          </View>
-        ) : (
-          <View style={styles.row}>
-            <AdaptableBadge
-              style={styles.badge}
-              textStyle={styles.badgeText}
-              text={departure?.localizedDate ?? ''}
-            />
-            <Text style={styles.connector}> to </Text>
-            {/* @TODO localize string `to` */}
-            <AdaptableBadge
-              style={styles.badge}
-              textStyle={styles.badgeText}
-              text={arrival?.localizedDate ?? ''}
-            />
-          </View>
-        )}
+          ) : (
+            <>
+              <AdaptableBadge
+                style={styles.badge}
+                textStyle={styles.badgeText}
+                text={departure?.localizedDate ?? ''}
+              />
+              <Text style={styles.connector}> to </Text>
+              {/* @TODO localize string `to` */}
+              <AdaptableBadge
+                style={styles.badge}
+                textStyle={styles.badgeText}
+                text={arrival?.localizedDate ?? ''}
+              />
+            </>
+          )}
+        </View>
       </View>
     </View>
   );


### PR DESCRIPTION


Summary: When going to /results page from a built nextjs application, getInitialProps and the likes are ignored. That meant that refreshing /results would return Error because the query params were not taken into account.

I used the solution from this comment https://github.com/zeit/next.js/issues/4804#issuecomment-451558569, and it works pretty well.

Caveat is that we show for a brief moment a sort of broken state. That should be improved.

![refresh](https://user-images.githubusercontent.com/22741774/52216399-610da380-2896-11e9-9af3-0a6c89d969b5.gif)