### PR TITLE
Fix: CircleCI should run `build-and-deploy-graphql` after `test` is successful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ workflows:
     jobs:
       - test
       - build-and-deploy-graphql:
+          requires:
+            - test
           filters:
             branches:
               only: master


### PR DESCRIPTION
~* Summary: We are already running the test when reviewing the PR, so it is not necessary to re-run the test after we merged into `master`; we can go straight to `build-and-deploy-graphql`.~