### PR TITLE
Feat: Improved font rendering

### DIFF
--- a/apps/web/pages/_document.js
+++ b/apps/web/pages/_document.js
@@ -22,6 +22,12 @@ const globalStyle = {
     font-family: 'orbit-icons';
     src: url(${OrbitIconFont});
   }
+
+  body {
+    -webkit-font-smoothing: antialiased;
+    height: 100%;
+    overflow: hidden;
+  }
 `,
 };
 
@@ -51,7 +57,7 @@ export default class MyDocument extends Document {
           />
           <style dangerouslySetInnerHTML={globalStyle} />
         </Head>
-        <body style={{ height: '100%', overflow: 'hidden' }}>
+        <body>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
Summary: Added `-webkit-font-smoothing` to global styles to improve fonts rendering on macOS.

Before:
<img width="110" alt="screenshot 2019-02-05 at 16 57 11" src="https://user-images.githubusercontent.com/2660330/52340772-f3d24d80-2a10-11e9-85db-8dc6da46ba95.png">

After (it's a subtle change visible mostly on bold and small text and font icons):
<img width="110" alt="screenshot 2019-02-05 at 16 57 55" src="https://user-images.githubusercontent.com/2660330/52340777-f765d480-2a10-11e9-94c7-e6dbd74b4eda.png">
