### PR TITLE
Chore: Upgrading @kiwicom/universal-components v0.0.11

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@kiwicom/margarita-navigation": "^0.0.0",
     "@kiwicom/orbit-design-tokens": "^0.2.5",
-    "@kiwicom/universal-components": "0.0.10"
+    "@kiwicom/universal-components": "0.0.11"
   },
   "devDependencies": {}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@kiwicom/margarita-utils": "^0",
-    "@kiwicom/universal-components": "0.0.10",
+    "@kiwicom/universal-components": "0.0.11",
     "react-native-shimmer-placeholder": "https://github.com/tomzaku/react-native-shimmer-placeholder.git#expo"
   },
   "devDependencies": {}

--- a/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
+++ b/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
@@ -58,21 +58,12 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
             "fontFamily": "Roboto",
             "margin": 0,
           },
-          undefined,
-          undefined,
-          Object {
-            "fontSize": 14,
-          },
           Object {
             "fontSize": 14,
           },
           Object {
             "color": "#46B655",
           },
-          Object {
-            "textAlign": "left",
-          },
-          undefined,
         ]
       }
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,10 +1146,10 @@
   dependencies:
     "@mrtnzlml/utils" "^1.1.1"
 
-"@kiwicom/universal-components@0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@kiwicom/universal-components/-/universal-components-0.0.10.tgz#a2d66b1f5371acd21e8a694e55c66ee1c5980980"
-  integrity sha512-c0MO3VTGUISXB1s3M+BFJdygKRUZL5/9nzO+a0gojvbt+PbMTH2DIYCJt+aPZSUn+nWuAaMJWckvGbWcvGG4+g==
+"@kiwicom/universal-components@0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@kiwicom/universal-components/-/universal-components-0.0.11.tgz#95f59497efaad99bfede39eec263da4686bf28be"
+  integrity sha512-/e5c77dpv7+WzeYNB41Xn8p/r6zbt2mn/4ZZfNnFDAH7/VhTpouXpl2Tzm6MWPG31XG6pbQEsKpY/0D5tC8J6Q==
   dependencies:
     "@kiwicom/orbit-design-tokens" "^0.3.0"
     react-native-modal "^7.0.2"
@@ -13827,9 +13827,9 @@ react-native-modal@^7.0.2:
     prop-types "^15.6.1"
     react-native-animatable "^1.2.4"
 
-"react-native-multi-slider@https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e":
+"react-native-multi-slider@git+https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e":
   version "2.0.3"
-  resolved "https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e"
+  resolved "git+https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e"
 
 react-native-reanimated@1.0.0-alpha.11:
   version "1.0.0-alpha.11"


### PR DESCRIPTION
Summary: `release-it` config was broken in @kiwicom/universal-components and v0.0.10 effectively shipped an old build... Some global exports were missing too.