### PR TITLE
Fix: Breaking Change in Datepicker introduced in universal-componetns…

### DIFF
--- a/apps/core/scenes/search/Datepickers.js
+++ b/apps/core/scenes/search/Datepickers.js
@@ -130,6 +130,7 @@ class Datepickers extends React.Component<Props, State> {
             minDate={startOfDay(new Date())}
             onConfirm={this.handleDateChange}
             onDismiss={this.handleDatePickerDismiss}
+            labels={{ cancel: 'Cancel', confirm: 'OK' }}
           />
         </View>
       </>


### PR DESCRIPTION
… v0.0.11

Summary: We need to inquire why Flow did not pick this up, as the `labels` prop is supposedly required...