### PR TITLE
Feat: Updated withContext children prop handling

### DIFF
--- a/packages/utils/src/withContext/withContext.js
+++ b/packages/utils/src/withContext/withContext.js
@@ -22,11 +22,8 @@ export default function withContext<T>(
       }
 
       render() {
-        const children = React.cloneElement(
-          this.props.children,
-          (this.props: Object),
-        );
-        return children;
+        const { children, ...props } = this.props;
+        return React.cloneElement(children, ({ ...props }: Object));
       }
     }
 
@@ -35,9 +32,11 @@ export default function withContext<T>(
       static navigationOptions = Component.navigationOptions;
       renderInner = (state: T) => {
         const stateProps = select(state);
+        const { children, ...props } = this.props;
+
         return (
-          <WithShouldComponentUpdate {...this.props} {...stateProps}>
-            <Component />
+          <WithShouldComponentUpdate {...props} {...stateProps}>
+            <Component>{children}</Component>
           </WithShouldComponentUpdate>
         );
       };


### PR DESCRIPTION
Summary: Extended `withContext` to handle elements with children prop. And prevent it to be overridden during `cloneElement`.

This update is necessary for future `LayoutContext` implementation inside `Layout` component to improve initial web rendering.