### PR TITLE
Fix: New Text component wrapper for bold and italic to work on mobile

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -4,6 +4,9 @@ import React from 'react';
 import * as Expo from 'expo';
 import { Buffer } from 'buffer';
 import Roboto from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-Regular.ttf';
+import RobotoItalic from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-Italic.ttf';
+import RobotoBold from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-Bold.ttf';
+import RobotoBoldItalic from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-BoldItalic.ttf';
 import OrbitIcons from '@kiwicom/universal-components/lib/fonts/orbit-icons.ttf';
 import { STORYBOOK } from 'react-native-dotenv';
 
@@ -37,6 +40,9 @@ class App extends React.Component<Props, State> {
   loadFonts = () =>
     Expo.Font.loadAsync({
       Roboto: Roboto,
+      RobotoItalic: RobotoItalic,
+      RobotoBold: RobotoBold,
+      RobotoBoldItalic: RobotoBoldItalic,
       'orbit-icons': OrbitIcons,
     });
 

--- a/packages/components/index.js
+++ b/packages/components/index.js
@@ -35,3 +35,4 @@ export {
 
 export { default as Separator } from './src/separator/Separator';
 export { default as ShareIcon } from './src/shareIcon/ShareIcon';
+export { default as Text } from './src/text/Text';

--- a/packages/components/src/SearchParamsSummary/SearchParamsSummary.js
+++ b/packages/components/src/SearchParamsSummary/SearchParamsSummary.js
@@ -6,9 +6,10 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import {
   Icon,
   StyleSheet,
-  Text,
   AdaptableBadge,
 } from '@kiwicom/universal-components';
+
+import Text from '../text/Text';
 
 type Trip = {|
   +city: string,
@@ -46,30 +47,34 @@ export default function SearchParamsSummary({
     <View style={styles.container}>
       <View style={styles.headerLeftContainer}>
         <View style={styles.citiesContainer}>
-          <Text style={styles.departureCity}>{departure?.city || ''}</Text>
+          <Text weight="bold" style={styles.city}>
+            {departure?.city}
+          </Text>
           <Icon name={icon} />
-          <Text style={styles.arrivalCity}>{arrival?.city || ''}</Text>
+          <Text weight="bold" style={styles.city}>
+            {arrival?.city}
+          </Text>
         </View>
         <View style={styles.row}>
           {tripType === 'OneWay' ? (
             <AdaptableBadge
               style={styles.badge}
               textStyle={styles.badgeText}
-              text={departure?.localizedDate ?? ''}
+              text={departure?.localizedDate}
             />
           ) : (
             <>
               <AdaptableBadge
                 style={styles.badge}
                 textStyle={styles.badgeText}
-                text={departure?.localizedDate ?? ''}
+                text={departure?.localizedDate}
               />
               <Text style={styles.connector}> to </Text>
               {/* @TODO localize string `to` */}
               <AdaptableBadge
                 style={styles.badge}
                 textStyle={styles.badgeText}
-                text={arrival?.localizedDate ?? ''}
+                text={arrival?.localizedDate}
               />
             </>
           )}
@@ -101,15 +106,8 @@ const styles = StyleSheet.create({
     paddingStart: 16,
     flex: 1,
   },
-  departureCity: {
-    fontWeight: 'bold',
+  city: {
     marginEnd: 5,
-    fontSize: parseFloat(defaultTokens.fontSizeTextLarge),
-    color: defaultTokens.colorTextAttention,
-  },
-  arrivalCity: {
-    fontWeight: 'bold',
-    marginStart: 5,
     fontSize: parseFloat(defaultTokens.fontSizeTextLarge),
     color: defaultTokens.colorTextAttention,
   },

--- a/packages/components/src/text/Text.js
+++ b/packages/components/src/text/Text.js
@@ -1,0 +1,50 @@
+// @flow
+
+import * as React from 'react';
+import { Platform } from 'react-native';
+import {
+  Text as UniversalComponentsText,
+  StyleSheet,
+} from '@kiwicom/universal-components';
+
+/**
+ * This wrapper is necessary because loading fonts with Expo does not allow using fontWeight and fontStyle
+ * cf. https://docs.expo.io/versions/latest/guides/using-custom-fonts/
+ */
+
+export default function Text(
+  props: $PropertyType<typeof UniversalComponentsText, 'props'>,
+) {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    return <UniversalComponentsText {...props} />;
+  }
+  const { italic, weight } = props;
+
+  let fontFamily = styles.normal;
+  if (italic && weight === 'bold') {
+    fontFamily = styles.boldItalic;
+  } else if (italic) {
+    fontFamily = styles.italic;
+  } else if (weight === 'bold') {
+    fontFamily = styles.bold;
+  }
+
+  return (
+    <UniversalComponentsText {...props} style={[props.style, fontFamily]} />
+  );
+}
+
+const styles = StyleSheet.create({
+  normal: {
+    fontFamily: 'Roboto',
+  },
+  bold: {
+    fontFamily: 'RobotoBold',
+  },
+  italic: {
+    fontFamily: 'RobotoItalic',
+  },
+  boldItalic: {
+    fontFamily: 'RobotoBoldItalic',
+  },
+});

--- a/packages/components/src/text/__tests__/Text.android.test.js
+++ b/packages/components/src/text/__tests__/Text.android.test.js
@@ -1,0 +1,29 @@
+// @flow
+
+import * as React from 'react';
+import { render } from 'react-native-testing-library';
+
+import Text from '../Text';
+
+jest.mock('Platform', () => ({
+  select: jest.fn(),
+  OS: 'android',
+}));
+
+describe('Text -- Android', () => {
+  it('should have the correct font family', () => {
+    const normal = render(<Text>Lorem</Text>);
+    const bold = render(<Text weight="bold">Lorem</Text>);
+    const italic = render(<Text italic>Lorem</Text>);
+    const boldItalic = render(
+      <Text italic weight="bold">
+        Lorem
+      </Text>,
+    );
+
+    expect(normal.toJSON()).toMatchSnapshot();
+    expect(bold.toJSON()).toMatchSnapshot();
+    expect(italic.toJSON()).toMatchSnapshot();
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/text/__tests__/Text.ios.test.js
+++ b/packages/components/src/text/__tests__/Text.ios.test.js
@@ -1,0 +1,29 @@
+// @flow
+
+import * as React from 'react';
+import { render } from 'react-native-testing-library';
+
+import Text from '../Text';
+
+jest.mock('Platform', () => ({
+  select: jest.fn(),
+  OS: 'ios',
+}));
+
+describe('Text -- iOS', () => {
+  it('should have the correct font family', () => {
+    const normal = render(<Text>Lorem</Text>);
+    const bold = render(<Text weight="bold">Lorem</Text>);
+    const italic = render(<Text italic>Lorem</Text>);
+    const boldItalic = render(
+      <Text italic weight="bold">
+        Lorem
+      </Text>,
+    );
+
+    expect(normal.toJSON()).toMatchSnapshot();
+    expect(bold.toJSON()).toMatchSnapshot();
+    expect(italic.toJSON()).toMatchSnapshot();
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/text/__tests__/Text.web.test.js
+++ b/packages/components/src/text/__tests__/Text.web.test.js
@@ -1,0 +1,34 @@
+// @flow
+
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { render } from 'react-native-testing-library';
+import { Text as UniversalComponentsText } from '@kiwicom/universal-components';
+
+import Text from '../Text';
+
+const originalPlatform = Platform.OS;
+
+beforeAll(() => {
+  Platform.OS = 'web';
+});
+
+afterAll(() => {
+  Platform.OS = originalPlatform;
+});
+
+describe('Text -- web', () => {
+  it("should render the same as Universal Components' Text", () => {
+    const universalComponentsText = render(
+      <UniversalComponentsText weight="bold" italic>
+        Lorem
+      </UniversalComponentsText>,
+    );
+    const text = render(
+      <Text weight="bold" italic>
+        Lorem
+      </Text>,
+    );
+    expect(universalComponentsText.toJSON()).toEqual(text.toJSON());
+  });
+});

--- a/packages/components/src/text/__tests__/__snapshots__/Text.android.test.js.snap
+++ b/packages/components/src/text/__tests__/__snapshots__/Text.android.test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text -- Android should have the correct font family 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "Roboto",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the correct font family 2`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "RobotoBold",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the correct font family 3`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "RobotoItalic",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the correct font family 4`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "RobotoBoldItalic",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;

--- a/packages/components/src/text/__tests__/__snapshots__/Text.ios.test.js.snap
+++ b/packages/components/src/text/__tests__/__snapshots__/Text.ios.test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text -- iOS should have the correct font family 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "Roboto",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the correct font family 2`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "RobotoBold",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the correct font family 3`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "RobotoItalic",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the correct font family 4`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontFamily": "RobotoBoldItalic",
+        },
+      ],
+    ]
+  }
+>
+  Lorem
+</Text>
+`;


### PR DESCRIPTION
Summary: Loading fonts with Expo does not allow the use of `fontStyle` and `fontWeight`, this PR adds a new Text wrapper component to be used instead of @kiwicom/universal-components' Text which takes into account weight='bold' and italic props for iOS and Android.

Note: Once all components use this new Text component, we should add an eslint rule to prevent Text import from '@kiwicom/universal-components'.