### PR TITLE
Refactor: Moved LayoutContext to _app.js

### DIFF
--- a/apps/web/components/Layout.js
+++ b/apps/web/components/Layout.js
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { StyleSheet } from '@kiwicom/universal-components';
-import { LayoutContextProvider } from '@kiwicom/margarita-utils';
 
 import Navbar from './Navbar';
 
@@ -16,12 +15,10 @@ type Props = {|
  */
 export default function Layout({ children }: Props) {
   return (
-    <LayoutContextProvider>
-      <View style={styles.container}>
-        <Navbar />
-        {children}
-      </View>
-    </LayoutContextProvider>
+    <View style={styles.container}>
+      <Navbar />
+      {children}
+    </View>
   );
 }
 

--- a/apps/web/components/__tests__/Layout.test.js
+++ b/apps/web/components/__tests__/Layout.test.js
@@ -15,19 +15,17 @@ it('renders', () => {
     ),
   ).toMatchInlineSnapshot(`
 Object {
-  "output": <LayoutContextProvider>
-    <Component
-      style={
-        Object {
-          "flex": 1,
-          "overflow": "hidden",
-        }
+  "output": <Component
+    style={
+      Object {
+        "flex": 1,
+        "overflow": "hidden",
       }
-    >
-      <Navbar />
-      <Component />
-    </Component>
-  </LayoutContextProvider>,
+    }
+  >
+    <Navbar />
+    <Component />
+  </Component>,
 }
 `);
 });
@@ -42,20 +40,18 @@ it('renders with multiple children', () => {
     ),
   ).toMatchInlineSnapshot(`
 Object {
-  "output": <LayoutContextProvider>
-    <Component
-      style={
-        Object {
-          "flex": 1,
-          "overflow": "hidden",
-        }
+  "output": <Component
+    style={
+      Object {
+        "flex": 1,
+        "overflow": "hidden",
       }
-    >
-      <Navbar />
-      <Component />
-      <Component />
-    </Component>
-  </LayoutContextProvider>,
+    }
+  >
+    <Navbar />
+    <Component />
+    <Component />
+  </Component>,
 }
 `);
 });

--- a/apps/web/pages/_app.js
+++ b/apps/web/pages/_app.js
@@ -1,0 +1,18 @@
+// @flow
+
+import * as React from 'react';
+import { default as NextApp, Container } from 'next/app';
+import { LayoutContextProvider } from '@kiwicom/margarita-utils';
+
+export default class App extends NextApp {
+  render() {
+    const { Component, pageProps } = this.props;
+    return (
+      <Container>
+        <LayoutContextProvider>
+          <Component {...pageProps} />
+        </LayoutContextProvider>
+      </Container>
+    );
+  }
+}


### PR DESCRIPTION
Summary: Moved `LayoutContextProvider` from `Layout` component to custom `App` in web version. 
To make context available in all sub-components.

Related to #231 