### PR TITLE
Chore: Use Text component wrapper in @kiwicom/margarita-components

### DIFF
--- a/packages/components/src/PlaceCard/PlaceCard.js
+++ b/packages/components/src/PlaceCard/PlaceCard.js
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { View } from 'react-native';
 import {
-  Text,
   StyleSheet,
   Touchable,
   AdaptableBadge,
@@ -13,6 +12,7 @@ import {
 // import BlackToAlpha from './assets/black-to-alpha-vertical.png'; @TODO
 import CityImage from './Image/CityImage';
 import Placeholder from './Placeholder';
+import Text from '../text/Text';
 
 type Props = {|
   +country: string,

--- a/packages/components/src/SearchParamsSummary/__tests__/index.test.js
+++ b/packages/components/src/SearchParamsSummary/__tests__/index.test.js
@@ -2,9 +2,11 @@
 
 import * as React from 'react';
 import { render } from 'react-native-testing-library';
-import { Icon, Text, AdaptableBadge } from '@kiwicom/universal-components';
+import { Icon, AdaptableBadge } from '@kiwicom/universal-components';
 
 import { SearchParamsSummary } from '..';
+
+import Text from '../../text/Text';
 
 const renderSearchParamsSummary = (tripType, component) => {
   const { getByType } = render(

--- a/packages/components/src/TimelineFlightDetail/components/AdditionalInfoCard.js
+++ b/packages/components/src/TimelineFlightDetail/components/AdditionalInfoCard.js
@@ -4,11 +4,12 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import {
-  Text,
   Icon,
   StyleSheet,
   type IconNameType,
 } from '@kiwicom/universal-components';
+
+import Text from '../../text/Text';
 
 type Info = {|
   +icon: IconNameType,

--- a/packages/components/src/TimelineFlightDetail/components/CardHeader.js
+++ b/packages/components/src/TimelineFlightDetail/components/CardHeader.js
@@ -3,13 +3,10 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import {
-  Icon,
-  CarrierLogo,
-  Text,
-  StyleSheet,
-} from '@kiwicom/universal-components';
+import { Icon, CarrierLogo, StyleSheet } from '@kiwicom/universal-components';
 import { capitalize } from '@kiwicom/margarita-utils';
+
+import Text from '../../text/Text';
 
 type Props = {|
   +expanded: boolean,

--- a/packages/components/src/TimelineInformation/TimelineCabinBaggage.js
+++ b/packages/components/src/TimelineInformation/TimelineCabinBaggage.js
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { Icon, Text, StyleSheet } from '@kiwicom/universal-components';
+import { Icon, StyleSheet } from '@kiwicom/universal-components';
 
 import TimelineInformation from './TimelineInformation';
+import Text from '../text/Text';
 
 type Props = {|
   +cabinBaggageWarning: string,

--- a/packages/components/src/TimelineInformation/TimelineDate.js
+++ b/packages/components/src/TimelineInformation/TimelineDate.js
@@ -1,9 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import { Icon, Text } from '@kiwicom/universal-components';
+import { Icon } from '@kiwicom/universal-components';
 
 import TimelineInformation from './TimelineInformation';
+import Text from '../text/Text';
 
 type Props = {|
   +formattedDate: string,

--- a/packages/components/src/TimelineInformation/TimelineDifferentAirport.js
+++ b/packages/components/src/TimelineInformation/TimelineDifferentAirport.js
@@ -1,9 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import { Icon, Text } from '@kiwicom/universal-components';
+import { Icon } from '@kiwicom/universal-components';
 
 import TimelineInformation from './TimelineInformation';
+import Text from '../text/Text';
 
 type Props = {|
   +differentAirportWarning: string,

--- a/packages/components/src/TimelineInformation/TimelineInformation.js
+++ b/packages/components/src/TimelineInformation/TimelineInformation.js
@@ -5,10 +5,11 @@ import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import {
   Icon,
-  Text,
   StyleSheet,
   type StylePropType,
 } from '@kiwicom/universal-components';
+
+import Text from '../text/Text';
 
 type Props = {|
   +icon: React.Element<typeof Icon>,

--- a/packages/components/src/TimelineInformation/TimelinePriorityBoarding.js
+++ b/packages/components/src/TimelineInformation/TimelinePriorityBoarding.js
@@ -1,9 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import { Icon, Text } from '@kiwicom/universal-components';
+import { Icon } from '@kiwicom/universal-components';
 
 import TimelineInformation from './TimelineInformation';
+import Text from '../text/Text';
 
 type Props = {|
   +information: string,

--- a/packages/components/src/TimelineInformation/__tests__/TimelineInformation.test.js
+++ b/packages/components/src/TimelineInformation/__tests__/TimelineInformation.test.js
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 import { render } from 'react-native-testing-library';
-import { Icon, Text } from '@kiwicom/universal-components';
+import { Icon } from '@kiwicom/universal-components';
 
 import { TimelineInformation } from '../index';
+import Text from '../../text/Text';
 
 describe('TimelineInformation', () => {
   const informationText = 'Lorem ipsum';

--- a/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
+++ b/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
@@ -64,6 +64,12 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
           Object {
             "color": "#46B655",
           },
+          Array [
+            undefined,
+            Object {
+              "fontFamily": "Roboto",
+            },
+          ],
         ]
       }
     >

--- a/packages/components/src/modal/__tests__/Modal.test.js
+++ b/packages/components/src/modal/__tests__/Modal.test.js
@@ -1,9 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { Text } from '@kiwicom/universal-components';
 import { shallow } from 'react-native-testing-library';
 
+import Text from '../../text/Text';
 import Modal from '../Modal';
 
 it('renders', () => {

--- a/packages/components/src/passengersButton/PassengersButton.js
+++ b/packages/components/src/passengersButton/PassengersButton.js
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Text, Icon } from '@kiwicom/universal-components';
+import { StyleSheet, Icon } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
+import Text from '../text/Text';
 import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
 import type { Props } from './PassengersButtonTypes';
 
@@ -22,7 +23,8 @@ export default function PassengersButton({ onPress, adults, infants }: Props) {
           color={defaultTokens.paletteInkNormal}
           name="passengers"
         />
-        <Text style={styles.text}>{`${adults + infants} ${label}`}</Text>
+        <Text weight="bold" style={styles.text}>{`${adults +
+          infants} ${label}`}</Text>
         <Icon
           size="small"
           color={defaultTokens.paletteInkNormal}
@@ -41,7 +43,6 @@ const styles = StyleSheet.create({
   text: {
     color: defaultTokens.paletteInkNormal,
     fontSize: parseInt(defaultTokens.fontSizeTextSmall, 10),
-    fontWeight: 'bold',
     marginHorizontal: 6,
   },
 });

--- a/packages/components/src/passengersButton/PassengersButton.native.js
+++ b/packages/components/src/passengersButton/PassengersButton.native.js
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Text, Icon } from '@kiwicom/universal-components';
+import { StyleSheet, Icon } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
+import Text from '../text/Text';
 import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
 import type { Props } from './PassengersButtonTypes';
 

--- a/packages/components/src/passengersInputs/PassengersInputs.js
+++ b/packages/components/src/passengersInputs/PassengersInputs.js
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Text, Button, StyleSheet } from '@kiwicom/universal-components';
+import { Button, StyleSheet } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
+import Text from '../text/Text';
 import type { Props, State } from './PassengersInputsTypes';
 import PassengersInputsLine from './PassengersInputsLine';
 import {

--- a/packages/components/src/passengersInputs/PassengersInputsLine.js
+++ b/packages/components/src/passengersInputs/PassengersInputsLine.js
@@ -2,8 +2,10 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Text, Icon, Stepper, StyleSheet } from '@kiwicom/universal-components';
+import { Icon, Stepper, StyleSheet } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import Text from '../text/Text';
 
 type Props = {|
   +icon: string,

--- a/packages/components/src/select/SelectOption.js
+++ b/packages/components/src/select/SelectOption.js
@@ -2,13 +2,10 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  StyleSheet,
-  Text,
-  Icon,
-  RadioButton,
-} from '@kiwicom/universal-components';
+import { StyleSheet, Icon, RadioButton } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import Text from '../text/Text';
 
 type OptionProps = {|
   +id: string,

--- a/packages/components/src/tripInput/TripInput.js
+++ b/packages/components/src/tripInput/TripInput.js
@@ -5,12 +5,12 @@ import { View, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import {
   StyleSheet,
-  Text,
   Icon,
   type StylePropType,
 } from '@kiwicom/universal-components';
 
 import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
+import Text from '../text/Text';
 
 type Props = {|
   +style?: StylePropType,

--- a/packages/components/src/tripTypeButton/TripTypeButton.js
+++ b/packages/components/src/tripTypeButton/TripTypeButton.js
@@ -2,10 +2,11 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Text, Icon } from '@kiwicom/universal-components';
+import { StyleSheet, Icon } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
+import Text from '../text/Text';
 
 type Props = {|
   +icon: string,

--- a/packages/components/src/tripTypeSwitch/TripTypeSwitchOption.js
+++ b/packages/components/src/tripTypeSwitch/TripTypeSwitchOption.js
@@ -1,11 +1,12 @@
 // @flow
 
 import * as React from 'react';
-import { StyleSheet, Text } from '@kiwicom/universal-components';
+import { StyleSheet } from '@kiwicom/universal-components';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
+import Text from '../text/Text';
 
 type Props = {|
   +type: string,
@@ -25,7 +26,10 @@ export default class TripTypeSwitchOption extends React.Component<Props> {
     return (
       <TouchableWithoutFeedback onPress={this.handlePress}>
         <View>
-          <Text style={[styles.switch, selected && styles.slectedSwitch]}>
+          <Text
+            weight="bold"
+            style={[styles.switch, selected && styles.slectedSwitch]}
+          >
             {label.toUpperCase()}
           </Text>
         </View>
@@ -37,7 +41,6 @@ export default class TripTypeSwitchOption extends React.Component<Props> {
 const styles = StyleSheet.create({
   switch: {
     fontSize: parseInt(defaultTokens.fontSizeTextNormal, 10),
-    fontWeight: 'bold',
     color: defaultTokens.paletteInkLightHover,
     marginEnd: parseInt(defaultTokens.spaceSmall, 10),
   },


### PR DESCRIPTION
Summary: This is a follow up PR to https://github.com/kiwicom/margarita/pull/248; we should use this Text wrapper component to ensure that `fontWeight` bold and `fontStyle` italic get applied correctly on iOS and Android through Expo.

Note that we should use `weight='bold'` and `italic` props instead of passing them through `style` prop (unless we need the text to be bold only on `web` for example).