### PR TITLE
Feat: Improved initial web rendering

### DIFF
--- a/apps/core/scenes/search/Search.js
+++ b/apps/core/scenes/search/Search.js
@@ -151,6 +151,7 @@ const styles = StyleSheet.create({
     marginBottom: 20,
     web: {
       marginTop: 20,
+      height: 200,
     },
   },
 });

--- a/apps/web/components/Layout.js
+++ b/apps/web/components/Layout.js
@@ -3,24 +3,33 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { StyleSheet } from '@kiwicom/universal-components';
+import {
+  withLayoutContext,
+  type LayoutContextState,
+} from '@kiwicom/margarita-utils';
 
 import Navbar from './Navbar';
 
 type Props = {|
+  +layoutReady: boolean,
   +children: React.Node | React.ChildrenArray<React.Node>,
 |};
 /**
  * This component should only be used by web.
  * react-navigation handles layout for mobile
  */
-export default function Layout({ children }: Props) {
+export const Layout = ({ layoutReady, children }: Props) => {
   return (
     <View style={styles.container}>
-      <Navbar />
-      {children}
+      {layoutReady && (
+        <>
+          <Navbar />
+          {children}
+        </>
+      )}
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -28,3 +37,9 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
 });
+
+const layoutSelect = ({ layoutReady }: LayoutContextState) => ({
+  layoutReady,
+});
+
+export default withLayoutContext(layoutSelect)(Layout);

--- a/apps/web/components/__tests__/Layout.test.js
+++ b/apps/web/components/__tests__/Layout.test.js
@@ -4,12 +4,12 @@ import * as React from 'react';
 import { shallow } from 'react-native-testing-library';
 import { View } from 'react-native';
 
-import Layout from '../Layout';
+import { Layout } from '../Layout';
 
 it('renders', () => {
   expect(
     shallow(
-      <Layout>
+      <Layout layoutReady>
         <View />
       </Layout>,
     ),
@@ -23,8 +23,10 @@ Object {
       }
     }
   >
-    <Navbar />
-    <Component />
+    <React.Fragment>
+      <Navbar />
+      <Component />
+    </React.Fragment>
   </Component>,
 }
 `);
@@ -33,7 +35,7 @@ Object {
 it('renders with multiple children', () => {
   expect(
     shallow(
-      <Layout>
+      <Layout layoutReady>
         <View />
         <View />
       </Layout>,
@@ -48,9 +50,11 @@ Object {
       }
     }
   >
-    <Navbar />
-    <Component />
-    <Component />
+    <React.Fragment>
+      <Navbar />
+      <Component />
+      <Component />
+    </React.Fragment>
   </Component>,
 }
 `);


### PR DESCRIPTION
Summary: Website content is shown after `layout` value initialisation, to prevent ugly layout reshuffling during initial render.

**Note:** I've tried to show spinner during `layout` initialisation but it just blinked for a few milliseconds which doesn't really improved experience.
So I've decided to remove it and simply show nothing during short initialisation, which looks better at the end.
 
Closes #231 