### PR TITLE
Fix: Fixed failing flow on CircleCI

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -62,6 +62,7 @@ node_modules/react-native/flow-github/
 flow-typed/
 
 [options]
+server.max_workers=4
 emoji=true
 
 module.name_mapper='^react-native$' -> 'react-native-web'


### PR DESCRIPTION
Summary: Added `max_workers` limit to flow configuration to prevent CircleCI consuming too many resources.

Found this solution after investigating CircleCI logs.
Where we have similar errors as mentioned in this issue https://github.com/flowtype/flow-bin/issues/138 with suggested solution.