### PR TITLE
Chore: Upgrading @kiwicom/universal-components v0.0.13

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -33,6 +33,13 @@
 ; Problems with this library which react-native-storybook-loader depends on
 .*/node_modules/findup/.*
 
+; TODO in universal-components
+<PROJECT_ROOT>/node_modules/@kiwicom/universal-components/lib/web/Loader/PageLoader.js.flow
+<PROJECT_ROOT>/node_modules/@kiwicom/universal-components/lib/web/TextInput/TextInput.js.flow
+<PROJECT_ROOT>/node_modules/@kiwicom/universal-components/lib/web/Text/Text.js.flow
+<PROJECT_ROOT>/node_modules/@kiwicom/universal-components/lib/web/TagsInput/components/InputField.js.flow
+<PROJECT_ROOT>/node_modules/@kiwicom/universal-components/lib/web/PlatformStyleSheet/StyleSheet.js.flow
+
 [include]
 
 [untyped]

--- a/.jest.json
+++ b/.jest.json
@@ -8,5 +8,8 @@
     "<rootDir>/apps/landingPage/.cache/__tests__/"
   ],
   "setupFilesAfterEnv": ["<rootDir>/scripts/setupTests.js"],
-  "transformIgnorePatterns": ["/node_modules/(?!@kiwicom)/"]
+  "transformIgnorePatterns": ["/node_modules/(?!@kiwicom)/"],
+  "moduleNameMapper": {
+    "^@kiwicom/universal-components$": "@kiwicom/universal-components/lib/native"
+  }
 }

--- a/apps/core/components/ItineraryCard/ItineraryCardWrapper.web.js
+++ b/apps/core/components/ItineraryCard/ItineraryCardWrapper.web.js
@@ -21,6 +21,8 @@ type Props = {|
   +layout: number,
 |};
 
+const noop = () => {}; // @TODO
+
 const ItineraryCardWrapper = ({ localizedPrice, children, layout }: Props) => {
   const mobileLayout = layout < LAYOUT.largeMobile;
 
@@ -44,6 +46,7 @@ const ItineraryCardWrapper = ({ localizedPrice, children, layout }: Props) => {
             label="Show Detail"
             type="secondary"
             rightIcon={<Icon name="chevron-down" />}
+            onPress={noop}
           />
         </View>
       )}

--- a/apps/core/components/ItineraryCard/TimelineArrow.js
+++ b/apps/core/components/ItineraryCard/TimelineArrow.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { StyleSheet, StylePropType } from '@kiwicom/universal-components';
+import { StyleSheet, type StylePropType } from '@kiwicom/universal-components';
 
 type ArrowProps = {
   arrowStyle?: StylePropType,

--- a/apps/core/components/ItineraryCard/Transporters.js
+++ b/apps/core/components/ItineraryCard/Transporters.js
@@ -19,16 +19,20 @@ const mapTransporters = (segments: SegmentsType) => {
     uniq(
       segments.map(segment => ({
         name: '',
-        code: segment && segment.transporter?.name,
+        code: (segment && segment.transporter?.name) ?? '',
       })),
     );
 
   return carriers;
 };
 function Transporters({ data }: Props) {
-  return (
-    <CarrierLogo size="medium" carriers={mapTransporters(data?.segments)} />
-  );
+  const carriers = mapTransporters(data?.segments);
+
+  if (carriers == null) {
+    return null;
+  }
+
+  return <CarrierLogo size="medium" carriers={carriers} />;
 }
 
 export default createFragmentContainer(

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@kiwicom/margarita-navigation": "^0.0.0",
     "@kiwicom/orbit-design-tokens": "^0.3.0",
-    "@kiwicom/universal-components": "0.0.11",
+    "@kiwicom/universal-components": "0.0.13",
     "@kiwicom/margarita-config":"^0",
     "@kiwicom/margarita-components":"^0",
     "@kiwicom/margarita-utils":"^0",

--- a/apps/core/scenes/bookingDetail/menuGroups/Manage.js
+++ b/apps/core/scenes/bookingDetail/menuGroups/Manage.js
@@ -35,7 +35,10 @@ class ManageMenuGroup extends React.Component<Props> {
     return (
       <MenuGroup title="manage" titleStyle={styles.menuGroupTitle}>
         <MenuItem
-          icon={<ShareIcon />}
+          icon={
+            // $FlowExpectedError clashing with class RNW$Text extends React$Component<RNW$Text$Props> from react-native-web flow-typed definitions
+            <ShareIcon />
+          }
           title="Invite co-traveller"
           onPress={this.onPressInvite}
         />

--- a/apps/core/scenes/bookingDetail/tripDetails/TripDate.js
+++ b/apps/core/scenes/bookingDetail/tripDetails/TripDate.js
@@ -26,7 +26,7 @@ const TripDate = (props: Props) => {
   const isDateType = props.type === 'date';
   const typeFormat = isDateType ? DAY_MONTH_DATE_FORMAT : HOURS_MINUTES_FORMAT;
   const textSize = isDateType ? 'normal' : 'small';
-  const textType = isDateType ? null : 'secondary';
+  const textType = isDateType ? 'primary' : 'secondary';
   const date = new Date(departureDate);
   return (
     <Text size={textSize} type={textType}>

--- a/apps/core/scenes/search/PlacePicker/PlaceItem.js
+++ b/apps/core/scenes/search/PlacePicker/PlaceItem.js
@@ -7,7 +7,7 @@ import {
   StyleSheet,
   Icon,
   Touchable,
-  StylePropType,
+  type StylePropType,
 } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';

--- a/apps/core/scenes/search/PlacePicker/PlacePickerContent.js
+++ b/apps/core/scenes/search/PlacePicker/PlacePickerContent.js
@@ -4,12 +4,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  Text,
-  TextInput,
-  Icon,
-  StyleSheet,
-} from '@kiwicom/universal-components';
+import { Text, TextInput, Icon } from '@kiwicom/universal-components';
 import {
   graphql,
   createRefetchContainer,
@@ -81,14 +76,12 @@ class PlacePickerContent extends React.Component<Props, State> {
     return (
       <>
         <View>
-          <View style={styles.label}>
-            <Text weight="bold">{this.getLabel()}</Text>
-          </View>
           <TextInput
             placeholder="Find a place"
             onChangeText={this.handleChangeText}
             value={this.state.text}
             prefix={<Icon name="search" />}
+            label={<Text weight="bold">{this.getLabel()}:</Text>}
           />
         </View>
         <PlacePickerList locations={this.props.locations?.locationsByTerm} />
@@ -96,12 +89,6 @@ class PlacePickerContent extends React.Component<Props, State> {
     );
   }
 }
-
-const styles = StyleSheet.create({
-  label: {
-    marginBottom: 8,
-  },
-});
 
 const select = ({ travelFrom, travelTo, modalType }: SearchContextState) => ({
   travelFrom,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@kiwicom/margarita-utils": "^0",
-    "@kiwicom/universal-components": "0.0.11",
+    "@kiwicom/universal-components": "0.0.13",
     "@storybook/react-native": "^4.0.6",
     "react-native-shimmer-placeholder": "https://github.com/tomzaku/react-native-shimmer-placeholder.git#expo"
   },

--- a/packages/components/src/Illustration/Illustration.js
+++ b/packages/components/src/Illustration/Illustration.js
@@ -14,7 +14,7 @@ const baseImagePath = (name, resolution: number) =>
 
 const RESOLUTIONS = [1, 2, 3];
 
-export default function Illustration({ name, style }: IllustrationProps) {
+export default function Illustration({ name, style = {} }: IllustrationProps) {
   return (
     <img
       src={baseImagePath(name, 1)}

--- a/packages/components/src/TimelineFlightDetail/TimelineFlightDetail.js
+++ b/packages/components/src/TimelineFlightDetail/TimelineFlightDetail.js
@@ -13,9 +13,9 @@ import CardHeader from './components/CardHeader';
 type Props = {|
   +additionalInfo: $PropertyType<AdditionalInfoProps, 'additionalInfo'>,
   +carrier: {|
-    +code: string,
-    +name: string,
-    +type?: 'airline' | 'bus' | 'train',
+    code: string,
+    name: string,
+    type?: 'airline' | 'bus' | 'train',
   |},
   +duration: string,
 |};
@@ -48,7 +48,7 @@ export default function TimelineFlightDetail({
       </View>
       <View style={styles.cardContainer}>
         <Accordion
-          defaultExpanded={true}
+          expandedDefault={true}
           header={Header({ carrier, duration })}
         >
           <AdditionalInfo additionalInfo={additionalInfo} />

--- a/packages/components/src/TimelineFlightDetail/components/CardHeader.js
+++ b/packages/components/src/TimelineFlightDetail/components/CardHeader.js
@@ -11,9 +11,9 @@ import Text from '../../text/Text';
 type Props = {|
   +expanded: boolean,
   +carrier: {|
-    +code: string,
-    +name: string,
-    +type?: 'airline' | 'bus' | 'train',
+    code: string,
+    name: string,
+    type?: 'airline' | 'bus' | 'train',
   |},
   +duration: string,
 |};

--- a/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
+++ b/packages/components/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
@@ -64,12 +64,9 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
           Object {
             "color": "#46B655",
           },
-          Array [
-            undefined,
-            Object {
-              "fontFamily": "Roboto",
-            },
-          ],
+          Object {
+            "fontFamily": "Roboto",
+          },
         ]
       }
     >

--- a/packages/components/src/duration/__tests__/__snapshots__/Duration.test.js.snap
+++ b/packages/components/src/duration/__tests__/__snapshots__/Duration.test.js.snap
@@ -15,6 +15,7 @@ exports[`works with broken input 1`] = `
     size="small"
   />
   <Text
+    expo={false}
     style={
       Array [
         Object {
@@ -45,6 +46,7 @@ exports[`works with broken input 2`] = `
     size="small"
   />
   <Text
+    expo={false}
     style={
       Array [
         Object {

--- a/packages/components/src/passengerCard/__tests__/__snapshots__/PassengerCard.test.js.snap
+++ b/packages/components/src/passengerCard/__tests__/__snapshots__/PassengerCard.test.js.snap
@@ -36,6 +36,7 @@ Object {
         name="passenger"
       />
       <Text
+        expo={false}
         size="large"
       >
         0. Passenger
@@ -90,6 +91,7 @@ Object {
         }
       >
         <Text
+          expo={false}
           style={
             Object {
               "paddingBottom": 8,
@@ -142,6 +144,7 @@ Object {
         name="passenger"
       />
       <Text
+        expo={false}
         size="large"
       >
         Mr. John Doe
@@ -196,6 +199,7 @@ Object {
         }
       >
         <Text
+          expo={false}
           style={
             Object {
               "paddingBottom": 8,

--- a/packages/components/src/passengersInputs/PassengersInputsLine.js
+++ b/packages/components/src/passengersInputs/PassengersInputsLine.js
@@ -2,13 +2,18 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Icon, Stepper, StyleSheet } from '@kiwicom/universal-components';
+import {
+  Icon,
+  Stepper,
+  StyleSheet,
+  type IconNameType,
+} from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import Text from '../text/Text';
 
 type Props = {|
-  +icon: string,
+  +icon: IconNameType,
   +label: string,
   +value: number,
   +min?: number,

--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -2,7 +2,11 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Button } from '@kiwicom/universal-components';
+import {
+  StyleSheet,
+  Button,
+  type IconNameType,
+} from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import SelectOption from './SelectOption';
@@ -10,7 +14,7 @@ import SelectOption from './SelectOption';
 type Props = {|
   +optionsData: {
     [string]: {|
-      +icon: string,
+      +icon: IconNameType,
       +label: string,
     |},
   },

--- a/packages/components/src/select/SelectOption.js
+++ b/packages/components/src/select/SelectOption.js
@@ -2,14 +2,19 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Icon, RadioButton } from '@kiwicom/universal-components';
+import {
+  StyleSheet,
+  Icon,
+  RadioButton,
+  type IconNameType,
+} from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import Text from '../text/Text';
 
 type OptionProps = {|
   +id: string,
-  +icon: string,
+  +icon: IconNameType,
   +label: string,
   +selected?: boolean,
   +underline?: boolean,

--- a/packages/components/src/shareIcon/ShareIcon.js
+++ b/packages/components/src/shareIcon/ShareIcon.js
@@ -2,11 +2,16 @@
 
 import * as React from 'react';
 import { Platform } from 'react-native';
-import { Icon, type StylePropType } from '@kiwicom/universal-components';
+import {
+  Icon,
+  type StylePropType,
+  type IconNameType,
+} from '@kiwicom/universal-components';
 
 type Size = 'small' | 'medium' | 'large';
 
 export type Props = {|
+  +name?: IconNameType,
   size?: Size,
   color?: string,
   style?: StylePropType,

--- a/packages/components/src/text/Text.js
+++ b/packages/components/src/text/Text.js
@@ -1,10 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { Platform } from 'react-native';
 import {
   Text as UniversalComponentsText,
-  StyleSheet,
+  type StylePropType,
 } from '@kiwicom/universal-components';
 
 /**
@@ -12,39 +11,30 @@ import {
  * cf. https://docs.expo.io/versions/latest/guides/using-custom-fonts/
  */
 
-export default function Text(
-  props: $PropertyType<typeof UniversalComponentsText, 'props'>,
-) {
-  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
-    return <UniversalComponentsText {...props} />;
-  }
-  const { italic, weight } = props;
+type Props = {|
+  align?: 'left' | 'right' | 'center' | 'justify',
+  +children: ?React.Node,
+  +dataTest?: string,
+  +italic?: boolean,
+  numberOfLines?: ?number,
+  size?: 'normal' | 'large' | 'small',
+  +style?: StylePropType,
+  +uppercase?: boolean,
+  +type?:
+    | 'attention'
+    | 'critical'
+    | 'info'
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'warning'
+    | 'white',
+  +weight?: 'normal' | 'bold',
+|};
 
-  let fontFamily = styles.normal;
-  if (italic && weight === 'bold') {
-    fontFamily = styles.boldItalic;
-  } else if (italic) {
-    fontFamily = styles.italic;
-  } else if (weight === 'bold') {
-    fontFamily = styles.bold;
+export default function Text(props: Props) {
+  if (props.children == null) {
+    return null;
   }
-
-  return (
-    <UniversalComponentsText {...props} style={[props.style, fontFamily]} />
-  );
+  return <UniversalComponentsText {...props} expo />;
 }
-
-const styles = StyleSheet.create({
-  normal: {
-    fontFamily: 'Roboto',
-  },
-  bold: {
-    fontFamily: 'RobotoBold',
-  },
-  italic: {
-    fontFamily: 'RobotoItalic',
-  },
-  boldItalic: {
-    fontFamily: 'RobotoBoldItalic',
-  },
-});

--- a/packages/components/src/text/__tests__/__snapshots__/Text.android.test.js.snap
+++ b/packages/components/src/text/__tests__/__snapshots__/Text.android.test.js.snap
@@ -8,12 +8,9 @@ exports[`Text -- Android should have the correct font family 1`] = `
         "fontFamily": "Roboto",
         "margin": 0,
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "Roboto",
-        },
-      ],
+      Object {
+        "fontFamily": "Roboto",
+      },
     ]
   }
 >
@@ -32,12 +29,9 @@ exports[`Text -- Android should have the correct font family 2`] = `
       Object {
         "fontWeight": "700",
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "RobotoBold",
-        },
-      ],
+      Object {
+        "fontFamily": "RobotoBold",
+      },
     ]
   }
 >
@@ -56,12 +50,9 @@ exports[`Text -- Android should have the correct font family 3`] = `
       Object {
         "fontStyle": "italic",
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "RobotoItalic",
-        },
-      ],
+      Object {
+        "fontFamily": "RobotoItalic",
+      },
     ]
   }
 >
@@ -83,12 +74,9 @@ exports[`Text -- Android should have the correct font family 4`] = `
       Object {
         "fontWeight": "700",
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "RobotoBoldItalic",
-        },
-      ],
+      Object {
+        "fontFamily": "RobotoBoldItalic",
+      },
     ]
   }
 >

--- a/packages/components/src/text/__tests__/__snapshots__/Text.ios.test.js.snap
+++ b/packages/components/src/text/__tests__/__snapshots__/Text.ios.test.js.snap
@@ -8,12 +8,9 @@ exports[`Text -- iOS should have the correct font family 1`] = `
         "fontFamily": "Roboto",
         "margin": 0,
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "Roboto",
-        },
-      ],
+      Object {
+        "fontFamily": "Roboto",
+      },
     ]
   }
 >
@@ -32,12 +29,9 @@ exports[`Text -- iOS should have the correct font family 2`] = `
       Object {
         "fontWeight": "700",
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "RobotoBold",
-        },
-      ],
+      Object {
+        "fontFamily": "RobotoBold",
+      },
     ]
   }
 >
@@ -56,12 +50,9 @@ exports[`Text -- iOS should have the correct font family 3`] = `
       Object {
         "fontStyle": "italic",
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "RobotoItalic",
-        },
-      ],
+      Object {
+        "fontFamily": "RobotoItalic",
+      },
     ]
   }
 >
@@ -83,12 +74,9 @@ exports[`Text -- iOS should have the correct font family 4`] = `
       Object {
         "fontWeight": "700",
       },
-      Array [
-        undefined,
-        Object {
-          "fontFamily": "RobotoBoldItalic",
-        },
-      ],
+      Object {
+        "fontFamily": "RobotoBoldItalic",
+      },
     ]
   }
 >

--- a/packages/components/src/tripInput/__tests__/TripInput.test.js
+++ b/packages/components/src/tripInput/__tests__/TripInput.test.js
@@ -12,7 +12,10 @@ it('renders', () => {
     shallow(
       <TripInput
         onPress={jest.fn()}
-        icon={<IconMock />}
+        icon={
+          // $FlowExpectedError: TripInput expects Icon component
+          <IconMock />
+        }
         label="label"
         value="value"
       />,
@@ -25,7 +28,10 @@ it('renders with placeholder', () => {
     shallow(
       <TripInput
         onPress={jest.fn()}
-        icon={<IconMock />}
+        icon={
+          // $FlowExpectedError: TripInput expects Icon component
+          <IconMock />
+        }
         label="label"
         value=""
         placeholder="placeholder"
@@ -39,7 +45,10 @@ it('renders correctly with placeholder and value', () => {
     shallow(
       <TripInput
         onPress={jest.fn()}
-        icon={<IconMock />}
+        icon={
+          // $FlowExpectedError: TripInput expects Icon component
+          <IconMock />
+        }
         label="label"
         value="value"
         placeholder="placeholder"

--- a/packages/components/src/tripTypeButton/TripTypeButton.js
+++ b/packages/components/src/tripTypeButton/TripTypeButton.js
@@ -2,14 +2,18 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Icon } from '@kiwicom/universal-components';
+import {
+  StyleSheet,
+  Icon,
+  type IconNameType,
+} from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
 import Text from '../text/Text';
 
 type Props = {|
-  +icon: string,
+  +icon: IconNameType,
   +label: string,
   +onPress: () => void,
 |};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,10 +1428,10 @@
   dependencies:
     "@mrtnzlml/utils" "^1.1.1"
 
-"@kiwicom/universal-components@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@kiwicom/universal-components/-/universal-components-0.0.11.tgz#95f59497efaad99bfede39eec263da4686bf28be"
-  integrity sha512-/e5c77dpv7+WzeYNB41Xn8p/r6zbt2mn/4ZZfNnFDAH7/VhTpouXpl2Tzm6MWPG31XG6pbQEsKpY/0D5tC8J6Q==
+"@kiwicom/universal-components@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@kiwicom/universal-components/-/universal-components-0.0.13.tgz#72ea43b6e49a43caeef4904f46db6b0d63fad8bc"
+  integrity sha512-76SBuF3Nht1yHEVjEz8nmaXVxotTrfKY7TvqhBPa4diTeumaTeaV04zkLyuQQkVpwzON9WjuPXFN4/3Vca+8Zw==
   dependencies:
     "@kiwicom/orbit-design-tokens" "^0.3.0"
     react-native-modal "^7.0.2"
@@ -15780,9 +15780,9 @@ react-native-modal@^7.0.2:
     prop-types "^15.6.1"
     react-native-animatable "^1.2.4"
 
-"react-native-multi-slider@https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e":
+"react-native-multi-slider@git+https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e":
   version "2.0.3"
-  resolved "https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e"
+  resolved "git+https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e"
 
 react-native-reanimated@1.0.0-alpha.11:
   version "1.0.0-alpha.11"


### PR DESCRIPTION
Summary: Now that Flow types are correctly being picked up, there were quite a few Flow errors to fix.
Some are related to using react-native-web flow-typed in this repo and they conflict with `@kiwicom/universal-components` in `node_modules`. These will have to be fixed there and they are ignored in this repo in .flowconfig file.
There was also an issue with how Jest resolves `@kiwicom/universal-components`: it only looks at the `main` field in `package.json`, and not at `react-native` field if preset is `jest-expo` or `react-native` in the config file`.jest.json`. That means that Jest resolved the web version of the components instead of the RN version.