### PR TITLE
Fix autocorrect in PlacePicker

### DIFF
--- a/apps/core/scenes/search/PlacePicker/PlacePickerContent.js
+++ b/apps/core/scenes/search/PlacePicker/PlacePickerContent.js
@@ -82,6 +82,8 @@ class PlacePickerContent extends React.Component<Props, State> {
             value={this.state.text}
             prefix={<Icon name="search" />}
             label={<Text weight="bold">{this.getLabel()}:</Text>}
+            autoCorrect={false}
+            autoFocus
           />
         </View>
         <PlacePickerList locations={this.props.locations?.locationsByTerm} />

--- a/apps/core/scenes/search/PlacePicker/PlacePickerList.js
+++ b/apps/core/scenes/search/PlacePicker/PlacePickerList.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { View, FlatList } from 'react-native';
+import { View, FlatList, Keyboard } from 'react-native';
 import { StyleSheet } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
@@ -29,6 +29,8 @@ const PlacePickerList = (props: Props) => {
         contentContainerStyle={styles.container}
         data={locations}
         keyExtractor={keyExtractor}
+        keyboardShouldPersistTaps="always"
+        onScroll={Keyboard.dismiss}
         renderItem={resultItem}
       />
     </View>


### PR DESCRIPTION
- enable autoFocus
- turn off autocorrect: It's annoying to write locations on iOS with autocorrect:

![screenshot 2019-02-13 at 11 34 28](https://user-images.githubusercontent.com/858321/52707375-d577cf00-2f87-11e9-89f6-34864071ea81.png)
