### PR TITLE
Refactor: TripSector web layout

### DIFF
--- a/apps/core/components/ItineraryCard/FlightTimes.js
+++ b/apps/core/components/ItineraryCard/FlightTimes.js
@@ -1,8 +1,9 @@
 // @flow
 
 import * as React from 'react';
+import { View, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, Text } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 
 import type { FlightTimes as FlightTimesType } from './__generated__/FlightTimes.graphql';
@@ -13,18 +14,31 @@ type Props = {|
 |};
 
 const FlightTimes = (props: Props) => (
-  <>
-    <LocalTime data={props.data?.departure} style={styles.highlightedText} />
-    <LocalTime data={props.data?.arrival} style={styles.highlightedText} />
-  </>
+  <View style={styles.container}>
+    <LocalTime data={props.data?.departure} style={styles.text} />
+    {Platform.OS === 'web' && <Text style={styles.text}> - </Text>}
+    <LocalTime data={props.data?.arrival} style={styles.text} />
+  </View>
 );
 
 const styles = StyleSheet.create({
-  highlightedText: {
+  container: {
+    minWidth: 55,
+    web: {
+      flexDirection: 'row',
+    },
+  },
+  text: {
     fontWeight: 'bold',
     fontSize: parseFloat(defaultTokens.fontSizeTextNormal),
     color: defaultTokens.colorTextAttention,
     padding: 5,
+    web: {
+      fontWeight: defaultTokens.fontWeightMedium,
+      color: '#2e353b', // @TODO repeating value - should be added to design-tokens
+      padding: 0,
+      lineHeight: 17,
+    },
   },
 });
 

--- a/apps/core/components/ItineraryCard/StopoverDuration.js
+++ b/apps/core/components/ItineraryCard/StopoverDuration.js
@@ -1,11 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { StyleSheet, Badge } from '@kiwicom/universal-components';
-import { View } from 'react-native';
 import * as DateFNS from 'date-fns';
 
-import ItineraryCardRow from './ItineraryCardRow';
+import StopoverDurationWrapper from './StopoverDurationWrapper';
 
 type Props = {|
   +stopoverDuration: ?number,
@@ -22,19 +20,14 @@ export default function StopoverDuration({
   stopoverDuration,
   locationName,
 }: Props) {
-  return stopoverDuration ? (
-    <ItineraryCardRow>
-      <View style={styles.leftShift}>
-        <Badge type="neutral">
-          Stays {getDuration(stopoverDuration)}
-          {locationName && ` in ${locationName}`}
-        </Badge>
-      </View>
-    </ItineraryCardRow>
-  ) : null;
+  if (stopoverDuration == null) {
+    return null;
+  }
+
+  return (
+    <StopoverDurationWrapper>
+      Stays {getDuration(stopoverDuration)}
+      {locationName && ` in ${locationName}`}
+    </StopoverDurationWrapper>
+  );
 }
-const styles = StyleSheet.create({
-  leftShift: {
-    paddingStart: 103,
-  },
-});

--- a/apps/core/components/ItineraryCard/StopoverDurationWrapper.native.js
+++ b/apps/core/components/ItineraryCard/StopoverDurationWrapper.native.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as React from 'react';
+import { StyleSheet, Badge } from '@kiwicom/universal-components';
+import { View } from 'react-native';
+
+import ItineraryCardRow from './ItineraryCardRow';
+
+type Props = {|
+  +children: React.Node,
+|};
+
+export default function StopoverDurationWrapper({ children }: Props) {
+  return (
+    <ItineraryCardRow>
+      <View style={styles.leftShift}>
+        <Badge type="neutral">{children}</Badge>
+      </View>
+    </ItineraryCardRow>
+  );
+}
+
+const styles = StyleSheet.create({
+  leftShift: {
+    paddingStart: 103,
+  },
+});

--- a/apps/core/components/ItineraryCard/StopoverDurationWrapper.web.js
+++ b/apps/core/components/ItineraryCard/StopoverDurationWrapper.web.js
@@ -1,0 +1,39 @@
+// @flow
+
+import * as React from 'react';
+import { StyleSheet, Text } from '@kiwicom/universal-components';
+import { View } from 'react-native';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+type Props = {|
+  +children: React.Node,
+|};
+
+export default function StopoverDurationWrapper({ children }: Props) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.dottedLine} />
+      <Text style={styles.stopoverText}>{children}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: parseInt(defaultTokens.spaceMedium, 10),
+    paddingStart: 0,
+  },
+  dottedLine: {
+    borderStyle: 'dotted',
+    borderColor: '#d2d9e0', // @TODO should be added to design-tokens
+    borderBottomWidth: 1,
+    width: parseInt(defaultTokens.widthIconLarge, 10),
+    marginEnd: 30,
+  },
+  stopoverText: {
+    color: '#57626c', // @TODO should be added to design-tokens
+    fontSize: parseInt(defaultTokens.fontSizeTextSmall, 10),
+  },
+});

--- a/apps/core/components/ItineraryCard/Transporters.js
+++ b/apps/core/components/ItineraryCard/Transporters.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import { Platform } from 'react-native';
 import { CarrierLogo } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { uniq } from 'ramda';
@@ -25,6 +26,7 @@ const mapTransporters = (segments: SegmentsType) => {
 
   return carriers;
 };
+
 function Transporters({ data }: Props) {
   const carriers = mapTransporters(data?.segments);
 
@@ -32,7 +34,12 @@ function Transporters({ data }: Props) {
     return null;
   }
 
-  return <CarrierLogo size="medium" carriers={carriers} />;
+  return (
+    <CarrierLogo
+      size={Platform.OS === 'web' ? 'large' : 'medium'}
+      carriers={carriers}
+    />
+  );
 }
 
 export default createFragmentContainer(

--- a/apps/core/components/ItineraryCard/TripCities.js
+++ b/apps/core/components/ItineraryCard/TripCities.js
@@ -1,8 +1,9 @@
 // @flow
 
 import * as React from 'react';
+import { View, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, Icon } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 
 import type { TripCities as TripCitiesType } from './__generated__/TripCities.graphql';
@@ -13,17 +14,37 @@ type Props = {|
 |};
 
 const TripCities = (props: Props) => (
-  <>
+  <View style={styles.container}>
     <LocationName data={props.data?.departure} style={styles.text} />
+    {Platform.OS === 'web' && (
+      <Icon
+        name="route-no-stops"
+        color={defaultTokens.colorIconTertiary}
+        size="large"
+      />
+    )}
     <LocationName data={props.data?.arrival} style={styles.text} />
-  </>
+  </View>
 );
 
 const styles = StyleSheet.create({
+  container: {
+    web: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: parseInt(defaultTokens.spaceXXSmall, 10),
+      height: 14,
+    },
+  },
   text: {
     fontSize: parseFloat(defaultTokens.fontSizeTextSmall),
     lineHeight: 17,
     padding: 5,
+    web: {
+      lineHeight: 14,
+      padding: 0,
+      color: defaultTokens.paletteInkLight,
+    },
   },
 });
 


### PR DESCRIPTION
Summary: Updated `TripSector` layout for web.

<img width="360" alt="screenshot 2019-02-15 at 11 08 41" src="https://user-images.githubusercontent.com/2660330/52850073-ebfe6180-3112-11e9-8776-737ceaf86c41.png">

Note: Because of Relay fragments I wasn't able to use our usual approach with `TripSector.native/web.js`. And which component should be rendered is handled inside `RenderTripSectorItem`. Reason for this is that even that component content is similar for both platforms, the layout and nesting is completely different.
The other option is to merge both component into one `TripSector` and decide which layout should be used inside. But I find this approach slightly cleaner because we have both layouts separated to smaller components/files so it's easier to read.