### PR TITLE
Refactor: better error message to the GraphQL console from the Fetch …

### DIFF
--- a/apps/graphql/src/services/Fetch.js
+++ b/apps/graphql/src/services/Fetch.js
@@ -66,7 +66,10 @@ export default async function fetch(
 
     return response.json();
   } catch (err) {
-    Logger.error(err);
+    Logger.error(`status: ${err.response.status} - ${err.response.statusText}`);
+
+    const response = await err.response.json();
+    Logger.error(response.message);
     throw err;
   }
 }


### PR DESCRIPTION
The logs in the console were not logged information from called API.
This is just a small improvement that should log API error in the console.

<img width="1338" alt="screen shot 2019-02-15 at 11 40 12" src="https://user-images.githubusercontent.com/6354326/52851493-8a3ff680-3116-11e9-92fa-982c412c9008.png">
