### PR TITLE
Graphql: Add RouteStop type to Sector and Segment

### DIFF
--- a/apps/graphql/src/dataloaders/ItinerariesloaderTypes.js
+++ b/apps/graphql/src/dataloaders/ItinerariesloaderTypes.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { type Location } from './LocationsloaderTypes';
+import type { RouteStop } from './bookingsLoader/BookingFlowTypes';
 
 export type ItinerariesSearchParameters = {|
   +travelFrom: string,
@@ -22,8 +23,8 @@ export type Price = {|
 |};
 
 export type Time = {|
-  +local: ?string,
-  +utc: ?string,
+  +local: ?(string | number),
+  +utc: ?(string | number),
 |};
 
 export type Transporter = {|
@@ -44,6 +45,8 @@ export type Segment = {|
   +origin: ?Location,
   +transporter: ?Transporter,
   +vehicle: ?Vehicle,
+  +arrival: ?RouteStop,
+  +departure: ?RouteStop,
 |};
 
 export type Sector = {|
@@ -54,6 +57,8 @@ export type Sector = {|
   +origin: ?Location,
   +segments: ?Array<Segment>,
   +stopoverDuration: number | null,
+  +departure: RouteStop,
+  +arrival: RouteStop,
 |};
 
 export type ItinerariesType = {|

--- a/apps/graphql/src/dataloaders/__tests__/itinerariesHelpers.test.js
+++ b/apps/graphql/src/dataloaders/__tests__/itinerariesHelpers.test.js
@@ -8,18 +8,13 @@ import {
   mapTransporter,
   mapSectors,
   mapVehicle,
-  sortRoute,
   differenceInMinutes,
 } from '../itinerariesHelpers';
 import {
-  oneWaySectors,
   oneWayRoutesList,
   oneWayRoutesMap,
-  twoWaySectors,
   twoWayRoutesList,
   twoWayRoutesMap,
-  unsortedRoute,
-  sortedRoute,
 } from '../__mocks__/itinerariesMock';
 
 describe('mapLocationArea', () => {
@@ -125,14 +120,10 @@ describe('mapTransporter', () => {
 
 describe('mapSectors', () => {
   it('returns an array with two Sectors for return flight', () => {
-    expect(mapSectors(twoWayRoutesList, twoWayRoutesMap)).toEqual(
-      twoWaySectors,
-    );
+    expect(mapSectors(twoWayRoutesList, twoWayRoutesMap)).toHaveLength(2);
   });
   it('returns an array with one Sector for one-way flight', () => {
-    expect(mapSectors(oneWayRoutesList, oneWayRoutesMap)).toEqual(
-      oneWaySectors,
-    );
+    expect(mapSectors(oneWayRoutesList, oneWayRoutesMap)).toHaveLength(1);
   });
   it('returns null if there are not enough of data for getting Sector', () => {
     expect(mapSectors()).toBeNull();
@@ -168,11 +159,5 @@ describe('differenceInMinutes', () => {
     expect(differenceInMinutes()).toBeNull();
     expect(differenceInMinutes(from)).toBeNull();
     expect(differenceInMinutes(null, to)).toBeNull();
-  });
-});
-
-describe('sortRoute', () => {
-  it('returns proper structure of the Country object', () => {
-    expect(sortRoute(unsortedRoute)).toMatchObject(sortedRoute);
   });
 });

--- a/apps/graphql/src/dataloaders/bookingsLoader/BookingFlowTypes.js
+++ b/apps/graphql/src/dataloaders/bookingsLoader/BookingFlowTypes.js
@@ -30,15 +30,15 @@ export type BookingApiResult = {|
 |};
 
 type RouteStopTime = {|
-  +utc: number,
-  +local: number,
+  +utc: ?(number | string),
+  +local: ?(number | string),
 |};
 
 export type RouteStop = {|
-  +cityName: string,
-  +cityId: string,
-  +time: RouteStopTime,
-  +code: string,
+  +cityName: ?string,
+  +cityId: ?string,
+  +time: ?RouteStopTime,
+  +code: ?string,
 |};
 
 export type Segment = {|

--- a/apps/graphql/src/datasets/Itineraries.json
+++ b/apps/graphql/src/datasets/Itineraries.json
@@ -1,0 +1,385 @@
+{
+  "ref_tasks": [],
+  "search_params": {
+    "to_type": "airport",
+    "flyFrom_type": "airport",
+    "seats": {
+      "infants": 0,
+      "passengers": 1,
+      "adults": 1,
+      "children": 0
+    }
+  },
+  "currency_rate": 1,
+  "refresh": [],
+  "connections": [],
+  "currency": "EUR",
+  "del": null,
+  "all_airlines": [],
+  "time": 1,
+  "all_stopover_airports": [],
+  "data": [
+    {
+      "quality": 994.998825,
+      "flyTo": "LIM",
+      "deep_link": "https://mock.url",
+      "nightsInDest": null,
+      "airlines": [
+        "ET",
+        "B6",
+        "VV",
+        "DY"
+      ],
+      "pnr_count": 4,
+      "baglimit": {},
+      "has_airport_change": false,
+      "distance": 11079.54,
+      "type_flights": [
+        "lcc-VV",
+        "lcc-ET",
+        "lcc-DY",
+        "lcc-B6"
+      ],
+      "bags_price": {},
+      "flyFrom": "OSL",
+      "cityFrom": "Oslo",
+      "booking_token": "token-1",
+      "duration": {
+        "total": 206100,
+        "return": 0,
+        "departure": 206100
+      },
+      "id": "3991227978220119_0|3915361603311185_0|8776301839864123_0|12345316616561678_0",
+      "conversion": {
+        "EUR": 525
+      },
+      "countryTo": {
+        "code": "PE",
+        "name": "Peru"
+      },
+      "price": 525,
+      "routes": [
+        [
+          "OSL",
+          "LIM"
+        ]
+      ],
+      "cityTo": "Lima",
+      "transfers": [],
+      "route": [
+        {
+          "refresh_timestamp": "1970-01-01T00:00:00.000Z",
+          "bags_recheck_required": false,
+          "return": 0,
+          "flight_no": 715,
+          "operating_carrier": "ET",
+          "cityTo": "Stockholm",
+          "vehicle_type": "aircraft",
+          "flyFrom": "OSL",
+          "id": "3991227978220119_0",
+          "equipment": "77L",
+          "combination_id": "3991227978220119",
+          "fare_family": "",
+          "flyTo": "ARN",
+          "airline": "ET",
+          "fare_classes": "E",
+          "cityFrom": "Oslo",
+          "last_seen": "2019-02-15T13:18:40.000Z",
+          "guarantee": false,
+          "fare_basis": "EOWNO",
+          "local_arrival": "2019-03-01T19:50:00.000Z",
+          "utc_arrival": "2019-03-01T18:50:00.000Z",
+          "local_departure": "2019-03-01T18:45:00.000Z",
+          "utc_departure": "2019-03-01T17:45:00.000Z"
+        },
+        {
+          "refresh_timestamp": "1970-01-01T00:00:00.000Z",
+          "bags_recheck_required": false,
+          "return": 0,
+          "flight_no": 7035,
+          "operating_carrier": null,
+          "cityTo": "Fort Lauderdale",
+          "vehicle_type": "aircraft",
+          "flyFrom": "ARN",
+          "id": "3915361603311185_0",
+          "equipment": null,
+          "combination_id": "3915361603311185",
+          "fare_family": "",
+          "flyTo": "FLL",
+          "airline": "DY",
+          "fare_classes": "",
+          "cityFrom": "Stockholm",
+          "last_seen": "2019-02-15T12:16:02.000Z",
+          "guarantee": true,
+          "fare_basis": "",
+          "local_arrival": "2019-03-02T19:45:00.000Z",
+          "utc_arrival": "2019-03-03T00:45:00.000Z",
+          "local_departure": "2019-03-02T15:15:00.000Z",
+          "utc_departure": "2019-03-02T14:15:00.000Z"
+        },
+        {
+          "refresh_timestamp": "2019-02-15T14:47:37.000Z",
+          "bags_recheck_required": false,
+          "return": 0,
+          "flight_no": 41,
+          "operating_carrier": "B6",
+          "cityTo": "Medellín",
+          "vehicle_type": "aircraft",
+          "flyFrom": "FLL",
+          "id": "8776301839864123_0",
+          "equipment": "320",
+          "combination_id": "8776301839864123",
+          "fare_family": "",
+          "flyTo": "MDE",
+          "airline": "B6",
+          "fare_classes": "",
+          "cityFrom": "Fort Lauderdale",
+          "last_seen": "2019-02-15T14:47:37.000Z",
+          "guarantee": true,
+          "fare_basis": "",
+          "local_arrival": "2019-03-03T02:24:00.000Z",
+          "utc_arrival": "2019-03-03T07:24:00.000Z",
+          "local_departure": "2019-03-02T22:55:00.000Z",
+          "utc_departure": "2019-03-03T03:55:00.000Z"
+        },
+        {
+          "refresh_timestamp": "1970-01-01T00:00:00.000Z",
+          "bags_recheck_required": false,
+          "return": 0,
+          "flight_no": 441,
+          "operating_carrier": "VV",
+          "cityTo": "Lima",
+          "vehicle_type": "aircraft",
+          "flyFrom": "MDE",
+          "id": "12345316616561678_0",
+          "equipment": "Non",
+          "combination_id": "12345316616561678",
+          "fare_family": "",
+          "flyTo": "LIM",
+          "airline": "VV",
+          "fare_classes": "",
+          "cityFrom": "Medellín",
+          "last_seen": "2019-02-15T12:41:52.000Z",
+          "guarantee": true,
+          "fare_basis": "",
+          "local_arrival": "2019-03-03T22:00:00.000Z",
+          "utc_arrival": "2019-03-04T03:00:00.000Z",
+          "local_departure": "2019-03-03T18:50:00.000Z",
+          "utc_departure": "2019-03-03T23:50:00.000Z"
+        }
+      ],
+      "baggage": {},
+      "facilitated_booking_available": false,
+      "countryFrom": {
+        "code": "NO",
+        "name": "Norway"
+      },
+      "local_arrival": "2019-03-03T22:00:00.000Z",
+      "utc_arrival": "2019-03-04T03:00:00.000Z",
+      "local_departure": "2019-03-01T18:45:00.000Z",
+      "utc_departure": "2019-03-01T17:45:00.000Z"
+    },
+    {
+      "quality": 941.465668,
+      "flyTo": "LIM",
+      "deep_link": "https://mock.url2",
+      "nightsInDest": null,
+      "airlines": [
+        "VH",
+        "DL",
+        "NK",
+        "DY"
+      ],
+      "pnr_count": 4,
+      "baglimit": {
+        "hold_weight": 18
+      },
+      "has_airport_change": false,
+      "distance": 11079.54,
+      "type_flights": [
+        "GDS-r",
+        "lcc-NK",
+        "lcc-DY",
+        "lcc-VH"
+      ],
+      "bags_price": {
+        "1": 165.65
+      },
+      "flyFrom": "OSL",
+      "booking_token": "token-2",
+      "cityFrom": "Oslo",
+      "duration": {
+        "total": 174360,
+        "return": 0,
+        "departure": 174360
+      },
+      "id": "3923058182037843_0|16669696135344215_0|10000058272100155_0|19795607481891218_0",
+      "conversion": {
+        "EUR": 542
+      },
+      "countryTo": {
+        "code": "PE",
+        "name": "Peru"
+      },
+      "price": 542,
+      "routes": [
+        [
+          "OSL",
+          "LIM"
+        ]
+      ],
+      "cityTo": "Lima",
+      "transfers": [],
+      "route": [
+        {
+          "refresh_timestamp": "1970-01-01T00:00:00.000Z",
+          "bags_recheck_required": false,
+          "return": 0,
+          "flight_no": 7001,
+          "operating_carrier": null,
+          "cityTo": "New York",
+          "vehicle_type": "aircraft",
+          "flyFrom": "OSL",
+          "id": "3923058182037843_0",
+          "equipment": null,
+          "combination_id": "3923058182037843",
+          "fare_family": "",
+          "flyTo": "JFK",
+          "airline": "DY",
+          "fare_classes": "",
+          "cityFrom": "Oslo",
+          "last_seen": "2019-02-15T12:58:48.000Z",
+          "guarantee": false,
+          "fare_basis": "",
+          "local_arrival": "2019-03-01T20:00:00.000Z",
+          "utc_arrival": "2019-03-02T01:00:00.000Z",
+          "local_departure": "2019-03-01T17:45:00.000Z",
+          "utc_departure": "2019-03-01T16:45:00.000Z"
+        },
+        {
+          "refresh_timestamp": "2019-02-15T14:15:41.000Z",
+          "bags_recheck_required": true,
+          "return": 0,
+          "flight_no": 2244,
+          "operating_carrier": "DL",
+          "cityTo": "Orlando",
+          "vehicle_type": "aircraft",
+          "flyFrom": "JFK",
+          "id": "16669696135344215_0",
+          "equipment": "321",
+          "combination_id": "16669696135344215",
+          "fare_family": "",
+          "flyTo": "MCO",
+          "airline": "DL",
+          "fare_classes": "E",
+          "cityFrom": "New York",
+          "last_seen": "2019-02-15T14:15:41.000Z",
+          "guarantee": true,
+          "fare_basis": "VAUSA0BP",
+          "local_arrival": "2019-03-02T11:01:00.000Z",
+          "utc_arrival": "2019-03-02T16:01:00.000Z",
+          "local_departure": "2019-03-02T08:05:00.000Z",
+          "utc_departure": "2019-03-02T13:05:00.000Z"
+        },
+        {
+          "refresh_timestamp": "1970-01-01T00:00:00.000Z",
+          "bags_recheck_required": true,
+          "return": 0,
+          "flight_no": 1921,
+          "operating_carrier": null,
+          "cityTo": "Bogotá",
+          "vehicle_type": "aircraft",
+          "flyFrom": "MCO",
+          "id": "10000058272100155_0",
+          "equipment": null,
+          "combination_id": "10000058272100155",
+          "fare_family": "",
+          "flyTo": "BOG",
+          "airline": "NK",
+          "fare_classes": "U",
+          "cityFrom": "Orlando",
+          "last_seen": "2019-02-15T08:09:42.000Z",
+          "guarantee": true,
+          "fare_basis": "UA14NR",
+          "local_arrival": "2019-03-03T00:15:00.000Z",
+          "utc_arrival": "2019-03-03T05:15:00.000Z",
+          "local_departure": "2019-03-02T19:55:00.000Z",
+          "utc_departure": "2019-03-03T00:55:00.000Z"
+        },
+        {
+          "refresh_timestamp": "1970-01-01T00:00:00.000Z",
+          "bags_recheck_required": true,
+          "return": 0,
+          "flight_no": 328,
+          "operating_carrier": null,
+          "cityTo": "Lima",
+          "vehicle_type": "aircraft",
+          "flyFrom": "BOG",
+          "id": "19795607481891218_0",
+          "equipment": null,
+          "combination_id": "19795607481891218",
+          "fare_family": "",
+          "flyTo": "LIM",
+          "airline": "VH",
+          "fare_classes": "",
+          "cityFrom": "Bogotá",
+          "last_seen": "2019-02-15T12:54:00.000Z",
+          "guarantee": true,
+          "fare_basis": "",
+          "local_arrival": "2019-03-03T12:11:00.000Z",
+          "utc_arrival": "2019-03-03T17:11:00.000Z",
+          "local_departure": "2019-03-03T09:00:00.000Z",
+          "utc_departure": "2019-03-03T14:00:00.000Z"
+        }
+      ],
+      "baggage": {
+        "hold": [
+          {
+            "weight": 18,
+            "price": 165.65,
+            "dimensions_sum": 156,
+            "height": 52,
+            "width": 26,
+            "length": 78,
+            "tier": "1"
+          },
+          {
+            "weight": 36,
+            "price": 398.56,
+            "dimensions_sum": 156,
+            "height": 52,
+            "width": 26,
+            "length": 78,
+            "tier": "3"
+          },
+          {
+            "weight": 20,
+            "price": 226.85,
+            "dimensions_sum": 156,
+            "height": 52,
+            "width": 26,
+            "length": 78,
+            "tier": "2"
+          }
+        ],
+        "personal_item": {
+          "width": 10,
+          "price": 0,
+          "length": 33,
+          "weight": 3,
+          "height": 25
+        }
+      },
+      "facilitated_booking_available": false,
+      "countryFrom": {
+        "code": "NO",
+        "name": "Norway"
+      },
+      "local_arrival": "2019-03-03T12:11:00.000Z",
+      "utc_arrival": "2019-03-03T17:11:00.000Z",
+      "local_departure": "2019-03-01T17:45:00.000Z",
+      "utc_departure": "2019-03-01T16:45:00.000Z"
+    }
+  ],
+  "search_id": "365557ea-6145-41da-8789-7f0f78a02453"
+}

--- a/apps/graphql/src/queries/__tests__/Itineraries.test.js
+++ b/apps/graphql/src/queries/__tests__/Itineraries.test.js
@@ -1,15 +1,40 @@
 // @flow
 
 import { graphql } from '../../services/TestingTools';
+import Itineraries from '../../datasets/Itineraries.json';
 
+const routeStopFragment = `
+cityName
+cityId
+time {
+  utc
+  local
+}`;
 it('works', async () => {
-  fetch.mockResponseOnce(JSON.stringify({ data: [{ id: 1 }, { id: 2 }] }));
+  fetch.mockResponseOnce(JSON.stringify(Itineraries));
   const query = `query($input: ItinerariesSearchInput!) {
 
     searchItineraries(input: $input) {
       edges {
         node {
-          id
+          sectors {
+            duration
+            stopoverDuration
+            segments {
+              departure {
+                ${routeStopFragment}
+              }
+              arrival {
+                ${routeStopFragment}
+              }
+            }
+            departure {
+              ${routeStopFragment}
+            }
+            arrival {
+              ${routeStopFragment}
+            }
+          }
         }
       }
     }
@@ -21,24 +46,5 @@ it('works', async () => {
         dateFrom: '2019-05-15',
       },
     }),
-  ).toMatchInlineSnapshot(`
-Object {
-  "data": Object {
-    "searchItineraries": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "SXRpbmVyYXJ5OjE=",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "SXRpbmVyYXJ5OjI=",
-          },
-        },
-      ],
-    },
-  },
-}
-`);
+  ).toMatchSnapshot();
 });

--- a/apps/graphql/src/queries/__tests__/__snapshots__/Itineraries.test.js.snap
+++ b/apps/graphql/src/queries/__tests__/__snapshots__/Itineraries.test.js.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`works 1`] = `
+Object {
+  "data": Object {
+    "searchItineraries": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "sectors": Array [
+              Object {
+                "arrival": Object {
+                  "cityId": "LIM",
+                  "cityName": "Lima",
+                  "time": Object {
+                    "local": "2019-03-03T22:00:00.000Z",
+                    "utc": "2019-03-04T03:00:00.000Z",
+                  },
+                },
+                "departure": Object {
+                  "cityId": "OSL",
+                  "cityName": "Oslo",
+                  "time": Object {
+                    "local": "2019-03-01T18:45:00.000Z",
+                    "utc": "2019-03-01T17:45:00.000Z",
+                  },
+                },
+                "duration": 3435,
+                "segments": Array [
+                  Object {
+                    "arrival": Object {
+                      "cityId": "ARN",
+                      "cityName": "Stockholm",
+                      "time": Object {
+                        "local": "2019-03-01T19:50:00.000Z",
+                        "utc": "2019-03-01T18:50:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "OSL",
+                      "cityName": "Oslo",
+                      "time": Object {
+                        "local": "2019-03-01T18:45:00.000Z",
+                        "utc": "2019-03-01T17:45:00.000Z",
+                      },
+                    },
+                  },
+                  Object {
+                    "arrival": Object {
+                      "cityId": "FLL",
+                      "cityName": "Fort Lauderdale",
+                      "time": Object {
+                        "local": "2019-03-02T19:45:00.000Z",
+                        "utc": "2019-03-03T00:45:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "ARN",
+                      "cityName": "Stockholm",
+                      "time": Object {
+                        "local": "2019-03-02T15:15:00.000Z",
+                        "utc": "2019-03-02T14:15:00.000Z",
+                      },
+                    },
+                  },
+                  Object {
+                    "arrival": Object {
+                      "cityId": "MDE",
+                      "cityName": "Medellín",
+                      "time": Object {
+                        "local": "2019-03-03T02:24:00.000Z",
+                        "utc": "2019-03-03T07:24:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "FLL",
+                      "cityName": "Fort Lauderdale",
+                      "time": Object {
+                        "local": "2019-03-02T22:55:00.000Z",
+                        "utc": "2019-03-03T03:55:00.000Z",
+                      },
+                    },
+                  },
+                  Object {
+                    "arrival": Object {
+                      "cityId": "LIM",
+                      "cityName": "Lima",
+                      "time": Object {
+                        "local": "2019-03-03T22:00:00.000Z",
+                        "utc": "2019-03-04T03:00:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "MDE",
+                      "cityName": "Medellín",
+                      "time": Object {
+                        "local": "2019-03-03T18:50:00.000Z",
+                        "utc": "2019-03-03T23:50:00.000Z",
+                      },
+                    },
+                  },
+                ],
+                "stopoverDuration": null,
+              },
+            ],
+          },
+        },
+        Object {
+          "node": Object {
+            "sectors": Array [
+              Object {
+                "arrival": Object {
+                  "cityId": "LIM",
+                  "cityName": "Lima",
+                  "time": Object {
+                    "local": "2019-03-03T12:11:00.000Z",
+                    "utc": "2019-03-03T17:11:00.000Z",
+                  },
+                },
+                "departure": Object {
+                  "cityId": "OSL",
+                  "cityName": "Oslo",
+                  "time": Object {
+                    "local": "2019-03-01T17:45:00.000Z",
+                    "utc": "2019-03-01T16:45:00.000Z",
+                  },
+                },
+                "duration": 2906,
+                "segments": Array [
+                  Object {
+                    "arrival": Object {
+                      "cityId": "JFK",
+                      "cityName": "New York",
+                      "time": Object {
+                        "local": "2019-03-01T20:00:00.000Z",
+                        "utc": "2019-03-02T01:00:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "OSL",
+                      "cityName": "Oslo",
+                      "time": Object {
+                        "local": "2019-03-01T17:45:00.000Z",
+                        "utc": "2019-03-01T16:45:00.000Z",
+                      },
+                    },
+                  },
+                  Object {
+                    "arrival": Object {
+                      "cityId": "MCO",
+                      "cityName": "Orlando",
+                      "time": Object {
+                        "local": "2019-03-02T11:01:00.000Z",
+                        "utc": "2019-03-02T16:01:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "JFK",
+                      "cityName": "New York",
+                      "time": Object {
+                        "local": "2019-03-02T08:05:00.000Z",
+                        "utc": "2019-03-02T13:05:00.000Z",
+                      },
+                    },
+                  },
+                  Object {
+                    "arrival": Object {
+                      "cityId": "BOG",
+                      "cityName": "Bogotá",
+                      "time": Object {
+                        "local": "2019-03-03T00:15:00.000Z",
+                        "utc": "2019-03-03T05:15:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "MCO",
+                      "cityName": "Orlando",
+                      "time": Object {
+                        "local": "2019-03-02T19:55:00.000Z",
+                        "utc": "2019-03-03T00:55:00.000Z",
+                      },
+                    },
+                  },
+                  Object {
+                    "arrival": Object {
+                      "cityId": "LIM",
+                      "cityName": "Lima",
+                      "time": Object {
+                        "local": "2019-03-03T12:11:00.000Z",
+                        "utc": "2019-03-03T17:11:00.000Z",
+                      },
+                    },
+                    "departure": Object {
+                      "cityId": "BOG",
+                      "cityName": "Bogotá",
+                      "time": Object {
+                        "local": "2019-03-03T09:00:00.000Z",
+                        "utc": "2019-03-03T14:00:00.000Z",
+                      },
+                    },
+                  },
+                ],
+                "stopoverDuration": null,
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+}
+`;

--- a/apps/graphql/src/types/output/RouteStop.js
+++ b/apps/graphql/src/types/output/RouteStop.js
@@ -27,6 +27,9 @@ export default new GraphQLObjectType({
         _: mixed,
         { dataLoader }: GraphqlContextType,
       ) => {
+        if (code == null) {
+          return null;
+        }
         const airport = await dataLoader.locations.load({ code });
         if (!Array.isArray(airport) || airport.length < 1) {
           return null;

--- a/apps/graphql/src/types/output/Sector.js
+++ b/apps/graphql/src/types/output/Sector.js
@@ -6,20 +6,43 @@ import { type Sector } from '../../dataloaders/ItinerariesloaderTypes';
 import DateType from './DateType';
 import Segment from './Segment';
 import Location from './Location';
+import GraphQLRouteStop from './RouteStop';
 
 export default new GraphQLObjectType({
   name: 'Sector',
   fields: {
-    arrivalTime: { type: DateType },
-    departureTime: { type: DateType },
-    destination: { type: Location },
-    duration: { type: GraphQLInt },
-    origin: { type: Location },
-    segments: { type: new GraphQLList(Segment) },
+    arrivalTime: {
+      type: DateType,
+      deprecationReason: 'Use arrival.time instead',
+    },
+    departureTime: {
+      type: DateType,
+      deprecationReason: 'Use departure.time instead',
+    },
+    destination: {
+      type: Location,
+      deprecationReason: 'Use arrival instead',
+    },
+    duration: {
+      type: GraphQLInt,
+    },
+    origin: {
+      type: Location,
+      deprecationReason: 'Use departure instead',
+    },
+    segments: {
+      type: new GraphQLList(Segment),
+    },
     stopoverDuration: {
       type: GraphQLInt,
       resolve: ({ stopoverDuration }: Sector): number | null =>
         stopoverDuration,
+    },
+    departure: {
+      type: GraphQLRouteStop,
+    },
+    arrival: {
+      type: GraphQLRouteStop,
     },
   },
 });

--- a/apps/graphql/src/types/output/Segment.js
+++ b/apps/graphql/src/types/output/Segment.js
@@ -7,17 +7,38 @@ import DateType from './DateType';
 import Vehicle from './Vehicle';
 import Transporter from './Transporter';
 import Location from './Location';
+import GraphQLRouteStop from './RouteStop';
 
 export default new GraphQLObjectType({
   name: 'Segment',
   fields: {
     id: GlobalID(({ id }) => id),
-    arrivalTime: { type: DateType },
-    departureTime: { type: DateType },
-    destination: { type: Location },
-    duration: { type: GraphQLInt },
-    origin: { type: Location },
-    transporter: { type: Transporter },
-    vehicle: { type: Vehicle },
+    arrivalTime: {
+      type: DateType,
+    },
+    departureTime: {
+      type: DateType,
+    },
+    destination: {
+      type: Location,
+    },
+    duration: {
+      type: GraphQLInt,
+    },
+    origin: {
+      type: Location,
+    },
+    transporter: {
+      type: Transporter,
+    },
+    vehicle: {
+      type: Vehicle,
+    },
+    departure: {
+      type: GraphQLRouteStop,
+    },
+    arrival: {
+      type: GraphQLRouteStop,
+    },
   },
 });

--- a/apps/graphql/src/types/output/Trip.js
+++ b/apps/graphql/src/types/output/Trip.js
@@ -27,8 +27,8 @@ export default new GraphQLObjectType({
     duration: {
       type: GraphQLInt,
       resolve: ({ departure, arrival }: Booking) => {
-        const departureRawTime = departure?.time.utc ?? 0;
-        const arrivalRawTime = arrival?.time.utc ?? 0;
+        const departureRawTime = parseInt(departure?.time?.utc, 10) ?? 0;
+        const arrivalRawTime = parseInt(arrival?.time?.utc, 10) ?? 0;
         const departureTimeMs = departureRawTime * 1000;
         const arrivalTimeMs = arrivalRawTime * 1000;
 


### PR DESCRIPTION
This should make reuse on FE easier when time and location is on same object.
Next iterations: Use new structure on FE.
Replace Trip type on MMB graphql with Sector type.