### PR TITLE
Graphql: strip timezone offset for search dates

### DIFF
--- a/apps/graphql/src/dataloaders/Itinerariesloader.js
+++ b/apps/graphql/src/dataloaders/Itinerariesloader.js
@@ -20,8 +20,11 @@ import type {
 
 const dateFormat = 'DD/MM/YYYY';
 
+const stripTimeZoneOffset = (date: Date) =>
+  DateFNS.addMinutes(date, date.getTimezoneOffset());
+
 const parseDate = (date: Date) =>
-  DateFNS.format(DateFNS.parse(date), dateFormat);
+  DateFNS.format(DateFNS.parse(stripTimeZoneOffset(date)), dateFormat);
 
 export const parseParameters = (input: ItinerariesSearchParameters) => {
   const params = {


### PR DESCRIPTION
This is to ensure that the date sent in = the date we search for
no matter what timezone we run the code in

closes #301