### PR TITLE
Grahpql: Add stopCoordinates to Segment type

### DIFF
--- a/apps/graphql/src/apps/common/types/outputs/Segment.js
+++ b/apps/graphql/src/apps/common/types/outputs/Segment.js
@@ -1,11 +1,26 @@
 // @flow
 
-import { GraphQLObjectType, GraphQLInt } from 'graphql';
+import { GraphQLObjectType, GraphQLInt, GraphQLList } from 'graphql';
 import GlobalID from '@kiwicom/graphql-global-id';
+import { head } from 'ramda';
 
 import GraphQLVehicle from './Vehicle';
 import GraphQLTransporter from './Transporter';
 import GraphQLRouteStop from './RouteStop';
+import GraphQLCoordinate from './Coordinate';
+import type { GraphqlContextType } from '../../../../services/graphqlContext/GraphQLContext';
+import type { Segment } from '../../../itinerary/Itinerary';
+import type { Location } from '../../../location/Location';
+
+const getCoordinateFromLocation = (location: ?Location) => {
+  if (location == null) {
+    return null;
+  }
+  return {
+    lat: location.coordinates?.lat,
+    lng: location.coordinates?.lng,
+  };
+};
 
 export default new GraphQLObjectType({
   name: 'Segment',
@@ -25,6 +40,31 @@ export default new GraphQLObjectType({
     },
     arrival: {
       type: GraphQLRouteStop,
+    },
+    stopCoordinates: {
+      type: GraphQLList(GraphQLCoordinate),
+      description: 'A list containing, departure and arrival gps-coordinates',
+      resolve: async (
+        { arrival, departure }: Segment,
+        _: mixed,
+        { dataLoader }: GraphqlContextType,
+      ) => {
+        const codes = [
+          { code: departure?.code ?? '' },
+          { code: arrival?.code ?? '' },
+        ];
+        const locations = await dataLoader.locations.loadMany(codes);
+
+        if (locations.length < 2) {
+          // We ask for 2 locations results, if we get less, there is an error
+          return null;
+        }
+
+        return [
+          getCoordinateFromLocation(head(locations[0])),
+          getCoordinateFromLocation(head(locations[1])),
+        ];
+      },
     },
   },
 });

--- a/apps/graphql/src/apps/common/types/outputs/__tests__/Segment.test.js
+++ b/apps/graphql/src/apps/common/types/outputs/__tests__/Segment.test.js
@@ -1,0 +1,62 @@
+// @flow
+
+import { evaluateGraphQLResolver } from '@kiwicom/test-utils';
+
+import Segment from '../Segment';
+
+const fields = Segment.getFields();
+
+describe('stopCoordinates', () => {
+  it('returns gps coordinates for the segment stops', async () => {
+    const departure = {
+      code: 'LIM',
+    };
+    const arrival = {
+      code: 'OSL',
+    };
+    const dataLoader = {
+      locations: {
+        loadMany: jest.fn(() => [
+          [
+            {
+              coordinates: {
+                lat: 5,
+                lng: 10,
+              },
+            },
+          ],
+          [
+            {
+              coordinates: {
+                lat: 25,
+                lng: 30,
+              },
+            },
+          ],
+        ]),
+      },
+    };
+
+    const result = await evaluateGraphQLResolver(
+      fields.stopCoordinates,
+      { arrival, departure },
+      null,
+      { dataLoader },
+    );
+
+    expect(result).toEqual([
+      {
+        lat: 5,
+        lng: 10,
+      },
+      {
+        lat: 25,
+        lng: 30,
+      },
+    ]);
+    expect(dataLoader.locations.loadMany).toHaveBeenCalledWith([
+      { code: 'LIM' },
+      { code: 'OSL' },
+    ]);
+  });
+});

--- a/flow-typed/npm/ramda_v0.26.x.js
+++ b/flow-typed/npm/ramda_v0.26.x.js
@@ -648,7 +648,7 @@ declare module ramda {
     fn: BinaryPredicateFn<T>,
   ): (xs: V) => Array<V>;
 
-  declare function head<T, V: Array<T>>(xs: V): ?T;
+  declare function head<T, V: Array<T> | $ReadOnlyArray<T>>(xs: V): ?T;
   declare function head<T, V: string>(xs: V): V;
 
   declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(


### PR DESCRIPTION
When drawing lines on the map we need to pass an array of
gps coordinates to the draw-line component. This field will make
the drawing of the map a lot easier than if we have to fetch
the coordinates from departure?.stop?.coordinates?.lat and
arrival?.stop?.coordinates?.lat