### PR TITLE
Fix: Wrong sector hours duration

### DIFF
--- a/apps/core/components/ItineraryCard/TripSector.js
+++ b/apps/core/components/ItineraryCard/TripSector.js
@@ -3,13 +3,14 @@
 import * as React from 'react';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { View, Platform } from 'react-native';
-import { Text, StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import {
   withLayoutContext,
   LAYOUT,
   type LayoutContextState,
 } from '@kiwicom/margarita-utils';
+import { Duration } from '@kiwicom/margarita-components';
 
 import type { TripSector as TripSectorType } from './__generated__/TripSector.graphql';
 import TimelineArrow from './TimelineArrow';
@@ -17,7 +18,7 @@ import Transporters from './Transporters';
 import FlightTimes from './FlightTimes';
 import LocalTime from './LocalTime';
 import TripCities from './TripCities';
-import { getDuration, dateFormat } from './TripSectorHelpers';
+import { dateFormat } from './TripSectorHelpers';
 
 type Props = {|
   +data: ?TripSectorType,
@@ -47,12 +48,11 @@ function TripSector({ data, layout }: Props) {
             dateFormat={dateFormat}
             style={[styles.infoText, styles.dateText]}
           />
-          <Text
+          <Duration
             style={[styles.infoText, styles.durationText]}
-            numberOfLines={1}
-          >
-            {getDuration(data?.duration)}
-          </Text>
+            showIcon={false}
+            duration={data?.duration}
+          />
         </View>
       </View>
     </View>

--- a/apps/core/components/ItineraryCard/TripSectorHelpers.js
+++ b/apps/core/components/ItineraryCard/TripSectorHelpers.js
@@ -4,16 +4,8 @@ import * as DateFNS from 'date-fns';
 
 export const timeSimpleFormat = 'H:mm';
 export const dateFormat = 'ddd D MMM';
-const durationFormat = 'H[h] m[m]';
+
 export const getFormattedDate = (
   time: ?string,
   format: ?string = timeSimpleFormat,
 ) => DateFNS.format(DateFNS.parse(time), format);
-
-export const getDuration = (durationInMinutes: ?number) => {
-  if (!durationInMinutes) {
-    return null;
-  }
-  const date = new Date(0, 0, 0, 0, durationInMinutes);
-  return DateFNS.format(date, durationFormat);
-};


### PR DESCRIPTION
Summary: Updated formatting to correctly handle duration longer than one day.

Before
<img width="315" alt="screenshot 2019-02-25 at 10 32 07" src="https://user-images.githubusercontent.com/2660330/53328374-1b1e8b00-38ea-11e9-8337-a572a3abc398.png">

After
<img width="312" alt="screenshot 2019-02-25 at 10 31 43" src="https://user-images.githubusercontent.com/2660330/53328394-25d92000-38ea-11e9-96a7-6ebb2311ec25.png">

Note: In next iteration we should move these helpers into `@kiwicom/margarita-utils` (it will be used by multiple components) and write proper tests for it.