### PR TITLE
Feat: Added weight prop to Duration component

### DIFF
--- a/packages/components/src/duration/Duration.js
+++ b/packages/components/src/duration/Duration.js
@@ -3,17 +3,19 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import {
-  Text,
   StyleSheet,
   Icon,
   type StylePropType,
 } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
+import Text from '../text/Text';
+
 type Props = {|
   +showIcon: boolean,
   +duration: ?number,
   +style?: StylePropType,
+  +weight?: 'normal' | 'bold',
   +iconStyle?: StylePropType,
 |};
 
@@ -43,7 +45,12 @@ export default function Duration(props: Props) {
           style={props.iconStyle}
         />
       )}
-      <Text style={[styleSheet.durationText, props.style]}>{duration}</Text>
+      <Text
+        weight={props.weight}
+        style={[styleSheet.durationText, props.style]}
+      >
+        {duration}
+      </Text>
     </View>
   );
 }

--- a/packages/components/src/duration/__tests__/__snapshots__/Duration.test.js.snap
+++ b/packages/components/src/duration/__tests__/__snapshots__/Duration.test.js.snap
@@ -15,7 +15,6 @@ exports[`works with broken input 1`] = `
     size="small"
   />
   <Text
-    expo={false}
     style={
       Array [
         Object {
@@ -46,7 +45,6 @@ exports[`works with broken input 2`] = `
     size="small"
   />
   <Text
-    expo={false}
     style={
       Array [
         Object {


### PR DESCRIPTION
Summary: `Duration` component text weight can be set to bold.
Required for `SectorDetail` header.

<img width="302" alt="screenshot 2019-02-25 at 18 04 08" src="https://user-images.githubusercontent.com/2660330/53355108-9737c380-3928-11e9-9928-9073e4797b55.png">
