### PR TITLE
Fix: Updated img path in docs getting-started

### DIFF
--- a/apps/documentation/pages/getting-started.md
+++ b/apps/documentation/pages/getting-started.md
@@ -1,4 +1,4 @@
-import yarnAnalyse from '../../../assets/yarn-analyze.png';
+import yarnAnalyse from '../assets/yarn-analyze.png';
 
 # Getting Started
 


### PR DESCRIPTION
Summary: `getting-started` was crashing because of wrong image path.