### PR TITLE
Chore: Dependabot schedule changed to weekly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
Summary: Added Dependabot config file and changed updates schedule to weekly.

More info about config options: https://dependabot.com/docs/config-file/#update_schedule-required

Note: Related to discussion: https://skypicker.slack.com/archives/CEFT2NAE8/p1550216049000500.
As mentioned on Dependabot website, this configuration doesn't affect security updates `We make an exception for security patches, which you'll always receive immediately.`.