### PR TITLE
Fix: Set correct TextInput fontFamily

### DIFF
--- a/packages/universal-components/src/TextInput/TextInput.js
+++ b/packages/universal-components/src/TextInput/TextInput.js
@@ -304,6 +304,7 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     padding: 0,
+    fontFamily: 'Roboto',
     web: {
       outline: 'none',
       color: defaultTokens.colorTextInput,

--- a/packages/universal-components/src/TextInput/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/TextInput/__tests__/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ exports[`TextInput should match snapshot diff between small and normal input 1`]
 -           \\"height\\": 44,
 +           \\"height\\": 32,
           },
-@@ -84,3 +84,3 @@
+@@ -85,3 +85,3 @@
             Object {
 -             \\"height\\": 44,
 +             \\"height\\": 32,


### PR DESCRIPTION
Summary: Switched from system default fontFamily to `Roboto`.

Before:
<img width="111" alt="screenshot 2019-03-06 at 12 38 14" src="https://user-images.githubusercontent.com/2660330/53879032-b65fe080-400d-11e9-9d91-ca9da22fcf8b.png">

After (Roboto is slightly more compact):
<img width="117" alt="screenshot 2019-03-06 at 12 37 34" src="https://user-images.githubusercontent.com/2660330/53879040-b9f36780-400d-11e9-9982-ccad0621b941.png">