### PR TITLE
Fix: Mobile Search layout

### DIFF
--- a/apps/core/scenes/search/Search.js
+++ b/apps/core/scenes/search/Search.js
@@ -102,7 +102,9 @@ class Search extends React.Component<Props> {
     return (
       <View style={styles.container}>
         <View style={[styles.form, desktopLayout && styles.formDesktop]}>
-          <Illustration name="Boarding" style={styles.boardingIllustration} />
+          <View style={styles.illustrationWrapper}>
+            <Illustration name="Boarding" style={styles.boardingIllustration} />
+          </View>
           <SearchFormModes />
 
           <View style={desktopLayout && styles.inputsDesktop}>
@@ -121,6 +123,7 @@ class Search extends React.Component<Props> {
               />
             </View>
           </View>
+          <View style={styles.bottomSpacer} />
         </View>
         <SearchModal />
       </View>
@@ -139,9 +142,9 @@ const styles = StyleSheet.create({
     },
   },
   form: {
+    flex: 1,
     width: '100%',
     maxWidth: 500,
-    marginBottom: 100,
     padding: parseInt(defaultTokens.spaceXSmall, 10),
     web: {
       maxWidth: 730,
@@ -169,11 +172,26 @@ const styles = StyleSheet.create({
       width: 130,
     },
   },
+  illustrationWrapper: {
+    flex: 5,
+    justifyContent: 'flex-end',
+    web: {
+      flex: 0,
+      flexBasis: 240,
+    },
+  },
   boardingIllustration: {
     marginBottom: 20,
+    height: '70%',
     web: {
-      marginTop: 20,
       height: 200,
+    },
+  },
+  bottomSpacer: {
+    flex: 1,
+    web: {
+      flex: 0,
+      flexBasis: 100,
     },
   },
 });


### PR DESCRIPTION
Summary: Updated mobile search screen layout for smaller devices.
Web version stays the same without any visible changes.

Closes #173

Before:
<img width="1229" alt="Screenshot 2019-03-12 at 18 17 27" src="https://user-images.githubusercontent.com/2660330/54221582-17972080-44f4-11e9-8816-ae6461e4e29a.png">

After:
<img width="1237" alt="Screenshot 2019-03-12 at 18 16 15" src="https://user-images.githubusercontent.com/2660330/54221570-11a13f80-44f4-11e9-8655-77262d456899.png">

Tablet:
<img width="564" alt="Screenshot 2019-03-13 at 09 24 36" src="https://user-images.githubusercontent.com/2660330/54263799-faa13280-4571-11e9-8042-af60009e965e.png">