### PR TITLE
Feat: Added margarita-design-tokens package

### DIFF
--- a/apps/core/components/ItineraryCard/FlightTimes.js
+++ b/apps/core/components/ItineraryCard/FlightTimes.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { View, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import { StyleSheet, Text } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 
@@ -35,7 +36,7 @@ const styles = StyleSheet.create({
     padding: 5,
     web: {
       fontWeight: '500',
-      color: '#2e353b', // @TODO repeating value - should be added to design-tokens
+      color: margaritaTokens.paletteBlueDark,
       padding: 0,
       lineHeight: 17,
     },

--- a/apps/core/components/ItineraryCard/ItineraryCard.js
+++ b/apps/core/components/ItineraryCard/ItineraryCard.js
@@ -6,6 +6,7 @@ import { formatPrice } from '@kiwicom/margarita-utils';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { TouchableWithoutFeedback } from '@kiwicom/margarita-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import { StyleSheet, Hoverable, Card } from '@kiwicom/universal-components';
 
 import RenderTripSectorItem from './RenderTripSectorItem';
@@ -140,7 +141,7 @@ const styles = StyleSheet.create({
     web: {
       alignSelf: 'center',
       width: '100%',
-      maxWidth: 720, // @TODO repeating value, should be added to design-tokens
+      maxWidth: margaritaTokens.widthScreenNormal,
       marginBottom: parseInt(defaultTokens.spaceMedium, 10),
       borderRadius: parseInt(defaultTokens.borderRadiusNormal, 10),
       boxShadow: '0 2px 4px 0 rgba(23,27,30,.1)',

--- a/apps/core/components/ItineraryCard/ItineraryCardWrapper.web.js
+++ b/apps/core/components/ItineraryCard/ItineraryCardWrapper.web.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import {
   StyleSheet,
   Icon,
@@ -85,7 +86,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     borderStyle: 'dotted',
-    borderColor: '#d2d9e0', // @TODO should be added to design-tokens
+    borderColor: margaritaTokens.borderColorInkLight,
     borderTopWidth: parseInt(defaultTokens.borderWidthCard, 10),
   },
 });

--- a/apps/core/components/ItineraryCard/StopoverDurationWrapper.web.js
+++ b/apps/core/components/ItineraryCard/StopoverDurationWrapper.web.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { StyleSheet, Text } from '@kiwicom/universal-components';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 type Props = {|
   +children: React.Node,
@@ -27,13 +28,13 @@ const styles = StyleSheet.create({
   },
   dottedLine: {
     borderStyle: 'dotted',
-    borderColor: '#d2d9e0', // @TODO should be added to design-tokens
+    borderColor: margaritaTokens.borderColorInkLight,
     borderBottomWidth: 1,
     width: parseInt(defaultTokens.widthIconLarge, 10),
     marginEnd: 30,
   },
   stopoverText: {
-    color: '#57626c', // @TODO should be added to design-tokens
+    color: margaritaTokens.borderColorInkNormal,
     fontSize: parseInt(defaultTokens.fontSizeTextSmall, 10),
   },
 });

--- a/apps/core/components/ItineraryCard/TripSector.js
+++ b/apps/core/components/ItineraryCard/TripSector.js
@@ -5,6 +5,7 @@ import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { View, Platform } from 'react-native';
 import { StyleSheet } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import {
   withLayoutContext,
   LAYOUT,
@@ -137,7 +138,7 @@ const styles = StyleSheet.create({
   dateText: {
     web: {
       fontSize: parseFloat(defaultTokens.fontSizeTextNormal),
-      color: '#2e353b', // @TODO repeating value - should be added to design-tokens
+      color: margaritaTokens.paletteBlueDark,
     },
   },
   durationText: {

--- a/apps/core/components/ItineraryCard/itineraryDetail/ItineraryDetailWrapper.web.js
+++ b/apps/core/components/ItineraryCard/itineraryDetail/ItineraryDetailWrapper.web.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { StyleSheet } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import type { Props } from './ItineraryDetailWrapperTypes';
 
@@ -13,7 +14,7 @@ export default function ItineraryDetailWrapper({ children }: Props) {
 
 const styles = StyleSheet.create({
   container: {
-    borderColor: '#d2dee8', // @TODO should be added to design-tokens
+    borderColor: margaritaTokens.borderColorInkLight,
     borderTopWidth: parseInt(defaultTokens.borderWidthCard, 10),
   },
 });

--- a/apps/core/components/priceSummary/PriceSummary.js
+++ b/apps/core/components/priceSummary/PriceSummary.js
@@ -5,6 +5,7 @@ import { Animated, View } from 'react-native';
 import { StyleSheet, Button } from '@kiwicom/universal-components';
 import { TouchableWithoutFeedback } from '@kiwicom/margarita-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import Expander from './Expander';
 
@@ -127,7 +128,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     start: 0,
     end: 0,
-    backgroundColor: defaultTokens.colorTextAttention, // @TODO tokens: this color should be named like background
+    backgroundColor: margaritaTokens.backdropColor,
   },
   container: {
     backgroundColor: defaultTokens.backgroundCard,

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -10,6 +10,7 @@
     "@kiwicom/margarita-navigation": "^0.0.0",
     "@kiwicom/margarita-relay": "^0",
     "@kiwicom/margarita-utils": "^0",
+    "@kiwicom/margarita-design-tokens": "^0",
     "@kiwicom/orbit-design-tokens": "^0.3.0",
     "@kiwicom/universal-components": "0.0.14",
     "geolib": "^2.0.24",

--- a/apps/core/scenes/passengerForm/PassengerForm.js
+++ b/apps/core/scenes/passengerForm/PassengerForm.js
@@ -9,6 +9,7 @@ import {
   TextInput,
 } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import { DateInput } from '@kiwicom/margarita-components';
 
 type Props = {||};
@@ -132,7 +133,7 @@ const styles = StyleSheet.create({
     backgroundColor: defaultTokens.paletteWhite,
     width: '100%',
     web: {
-      maxWidth: 720, // @TODO repeating value, should be added to design-tokens
+      maxWidth: margaritaTokens.widthScreenNormal,
     },
   },
   inputLabel: {

--- a/apps/core/scenes/results/Results.js
+++ b/apps/core/scenes/results/Results.js
@@ -6,6 +6,7 @@ import { QueryRenderer, graphql } from '@kiwicom/margarita-relay';
 import { StyleSheet } from '@kiwicom/universal-components';
 import * as DateFNS from 'date-fns';
 import { SearchParamsSummary } from '@kiwicom/margarita-components';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import type { ResultsQueryResponse } from './__generated__/ResultsQuery.graphql';
 import ResultsList from './ResultsList';
@@ -20,8 +21,6 @@ type Props = {|
   +returnDateFrom: string,
   +returnDateTo: string,
 |};
-
-const statusBarHeight = 20; // @TODO add to orbit design tokens
 
 export default class Results extends React.Component<Props> {
   renderInner = (props: ResultsQueryResponse) => {
@@ -84,7 +83,7 @@ export default class Results extends React.Component<Props> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: statusBarHeight,
+    marginTop: margaritaTokens.heightStatusBar,
     web: {
       marginTop: 0,
     },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -18,6 +18,7 @@ module.exports = withImages(
       '@kiwicom/margarita-navigation',
       '@kiwicom/margarita-config',
       '@kiwicom/margarita-map',
+      '@kiwicom/margarita-design-tokens',
     ],
     webpack: (config, { isServer }) => {
       // Bundle Analyzer

--- a/packages/design-tokens/index.js
+++ b/packages/design-tokens/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export { margaritaTokens } from './src/MargaritaTokens';

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kiwicom/margarita-design-tokens",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/design-tokens/src/MargaritaTokens.js
+++ b/packages/design-tokens/src/MargaritaTokens.js
@@ -1,0 +1,16 @@
+// @flow
+
+export const margaritaTokens = {
+  widthScreenNormal: 720,
+  heightStatusBar: 20,
+  paletteBlueDark: '#2e353b',
+  borderColorInkLight: '#d2d9e0',
+  borderColorInkNormal: '#57626c',
+  backdropColor: '#171b1e',
+
+  heightBadge: 18,
+  backgroundBadgeWarning: '#F9971E',
+  backgroundBadgeWhite: '#F5F7F9',
+  colorTextBadgeWarning: '#FFFFFF',
+  colorTextBadgeWhite: '#7F91A8',
+};

--- a/packages/universal-components/package.json
+++ b/packages/universal-components/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@kiwicom/orbit-design-tokens": "^0.3.0",
+    "@kiwicom/margarita-design-tokens": "^0",
     "@storybook/react-native": "^4.1.13",
     "react-native-modal": "^7.0.2",
     "react-native-multi-slider": "https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e",

--- a/packages/universal-components/src/Badge/Badge.js
+++ b/packages/universal-components/src/Badge/Badge.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import { Text } from '../Text';
 import { StyleSheet } from '../PlatformStyleSheet';
@@ -48,7 +49,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: parseFloat(defaultTokens.fontSizeTextSmall),
-    lineHeight: 18, // @TODO parseFloat(defaultTokens.heightBadge) - after design tokens update
+    lineHeight: margaritaTokens.heightBadge,
     fontWeight: '500',
     letterSpacing: 0.3,
     color: defaultTokens.colorTextBadgeDark,

--- a/packages/universal-components/src/Badge/styles/index.js
+++ b/packages/universal-components/src/Badge/styles/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 export const wrapperColor = {
   primary: defaultTokens.paletteProductNormal,
@@ -9,8 +10,8 @@ export const wrapperColor = {
   info: defaultTokens.backgroundBadgeInfo,
   neutral: defaultTokens.backgroundBadgeNeutral,
   success: defaultTokens.backgroundBadgeSuccess,
-  warning: '#F9971E', // @TODO defaultTokens.backgroundBadgeWarning - after design tokens update
-  white: '#F5F7F9', // @TODO defaultTokens.backgroundBadgeWhite - after design tokens update
+  warning: margaritaTokens.backgroundBadgeWarning,
+  white: margaritaTokens.backgroundBadgeWhite,
 };
 
 export const textColor = {
@@ -20,6 +21,6 @@ export const textColor = {
   info: defaultTokens.colorTextBadgeInfo,
   neutral: defaultTokens.colorTextBadgeNeutral,
   success: defaultTokens.colorTextBadgeSuccess,
-  warning: '#FFFFFF', // @TODO defaultTokens.colorTextBadgeWarning - after design tokens update
-  white: '#7F91A8', // @TODO defaultTokens.colorTextBadgeWhite - after design tokens update
+  warning: margaritaTokens.colorTextBadgeWarning,
+  white: margaritaTokens.colorTextBadgeWhite,
 };

--- a/packages/universal-components/src/LocalizedPrice/LocalizedPrice.js
+++ b/packages/universal-components/src/LocalizedPrice/LocalizedPrice.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import { Text } from '../Text';
 import { StyleSheet } from '../PlatformStyleSheet';
@@ -24,7 +25,7 @@ const styles = StyleSheet.create({
     color: defaultTokens.colorTextLinkPrimary,
     fontSize: parseFloat(defaultTokens.fontSizeTextLarge),
     web: {
-      color: '#2e353b', // // @TODO repeating value - should be added to design-tokens
+      color: margaritaTokens.paletteBlueDark,
       fontSize: 18,
     },
   },


### PR DESCRIPTION
Summary: Added `@kiwicom/margarita-design-tokens` to store repeating style values which are currently missing in `orbit-design-tokens`.
Cleaned code from related todos.

Note: I've tried to use as generic names as possible where it makes sense. And kept original names if we just replacing actual value from orbit, like in case of badges.
But I'm definitely open to any other suggestions.

Closes #136