### PR TITLE
Fix: Get rid of type 'disabled' in favour of the html disabled prop

### DIFF
--- a/packages/universal-components/src/Button/Button.stories.js
+++ b/packages/universal-components/src/Button/Button.stories.js
@@ -34,7 +34,6 @@ storiesOf('Button', module)
         'critical',
         'facebook',
         'google',
-        'disabled',
       ],
       'primary',
     );
@@ -127,7 +126,12 @@ storiesOf('Button', module)
         <Separator />
         <Button onPress={noop} type="google" label={googleLabel} />
         <Separator />
-        <Button onPress={noop} type="disabled" label={disabledLabel} />
+        <Button
+          onPress={noop}
+          type="primary"
+          label={disabledLabel}
+          disabled={true}
+        />
         <Separator />
         <Button
           onPress={noop}
@@ -172,7 +176,9 @@ storiesOf('Button', module)
   })
   .add('disabled', () => {
     const label = text('label', 'Some random text');
-    return <Button onPress={noop} type="disabled" label={label} />;
+    return (
+      <Button onPress={noop} type="primary" label={label} disabled={true} />
+    );
   })
   .add('with children', () => (
     <Button onPress={noop} type="info">

--- a/packages/universal-components/src/Button/ButtonTypes.js
+++ b/packages/universal-components/src/Button/ButtonTypes.js
@@ -12,8 +12,7 @@ export type ButtonType =
   | 'warning'
   | 'critical'
   | 'facebook'
-  | 'google'
-  | 'disabled';
+  | 'google';
 
 export type Props = {|
   +onPress: () => void,

--- a/packages/universal-components/src/Button/styles/shared.js
+++ b/packages/universal-components/src/Button/styles/shared.js
@@ -9,7 +9,6 @@ export const textColor = {
   critical: defaultTokens.colorTextButtonCritical,
   facebook: defaultTokens.colorTextButtonFacebook,
   google: defaultTokens.colorTextButtonGoogle,
-  disabled: defaultTokens.paletteInkLighter,
 };
 
 export const wrapperColor = {
@@ -19,5 +18,4 @@ export const wrapperColor = {
   critical: defaultTokens.backgroundButtonCritical,
   facebook: defaultTokens.backgroundButtonFacebook,
   google: defaultTokens.backgroundButtonGoogle,
-  disabled: defaultTokens.paletteCloudLight,
 };


### PR DESCRIPTION
The `disabled` type did not necessarily set the HTML disabled property on the elements. Hence, the styling was applied (cursor, opacity) but the click events were actually performed. We got rid of the disabled type in favour of the html disabled prop which sets the styles and also prevents the click.

Fixes #473 