### PR TITLE
Feat: Added ThemeProvider

### DIFF
--- a/apps/core/scenes/bookingDetail/menuGroups/Passengers/__tests__/__snapshots__/Bag.test.js.snap
+++ b/apps/core/scenes/bookingDetail/menuGroups/Passengers/__tests__/__snapshots__/Bag.test.js.snap
@@ -22,13 +22,12 @@ Object {
         name="baggage-checked"
         size="small"
       />
-      <Text
-        expo={false}
+      <WithTheme
         size="small"
         type="primary"
       >
         3 Cabin bags
-      </Text>
+      </WithTheme>
     </Component>
   </React.Fragment>,
 }
@@ -50,13 +49,12 @@ Object {
         name="baggage-checked"
         size="small"
       />
-      <Text
-        expo={false}
+      <WithTheme
         size="small"
         type="primary"
       >
         3 Checked baggage
-      </Text>
+      </WithTheme>
     </Component>
   </React.Fragment>,
 }
@@ -78,13 +76,12 @@ Object {
         name="baggage-checked"
         size="small"
       />
-      <Text
-        expo={false}
+      <WithTheme
         size="small"
         type="primary"
       >
         3 Personal items
-      </Text>
+      </WithTheme>
     </Component>
   </React.Fragment>,
 }

--- a/packages/components/src/passengerCard/__tests__/__snapshots__/PassengerCard.test.js.snap
+++ b/packages/components/src/passengerCard/__tests__/__snapshots__/PassengerCard.test.js.snap
@@ -23,8 +23,7 @@ Object {
         <Icon
           name="passenger"
         />
-        <Text
-          expo={false}
+        <WithTheme
           size="large"
           style={
             Object {
@@ -33,7 +32,7 @@ Object {
           }
         >
           0. Passenger
-        </Text>
+        </WithTheme>
       </Component>
       <Component
         style={
@@ -83,8 +82,7 @@ Object {
             }
           }
         >
-          <Text
-            expo={false}
+          <WithTheme
             style={
               Object {
                 "paddingBottom": 8,
@@ -93,7 +91,7 @@ Object {
             type="secondary"
           >
             Bags
-          </Text>
+          </WithTheme>
           <Component />
         </Component>
       </Component>
@@ -125,8 +123,7 @@ Object {
         <Icon
           name="passenger"
         />
-        <Text
-          expo={false}
+        <WithTheme
           size="large"
           style={
             Object {
@@ -135,7 +132,7 @@ Object {
           }
         >
           Mr. John Doe
-        </Text>
+        </WithTheme>
       </Component>
       <Component
         style={
@@ -185,8 +182,7 @@ Object {
             }
           }
         >
-          <Text
-            expo={false}
+          <WithTheme
             style={
               Object {
                 "paddingBottom": 8,
@@ -195,7 +191,7 @@ Object {
             type="secondary"
           >
             Bags
-          </Text>
+          </WithTheme>
           <Component>
             <BagInformation
               count={2}

--- a/packages/components/src/text/__tests__/__snapshots__/Text.android.test.js.snap
+++ b/packages/components/src/text/__tests__/__snapshots__/Text.android.test.js.snap
@@ -5,7 +5,6 @@ exports[`Text -- Android should have the correct font family 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -23,7 +22,6 @@ exports[`Text -- Android should have the correct font family 2`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -44,7 +42,6 @@ exports[`Text -- Android should have the correct font family 3`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -65,7 +62,6 @@ exports[`Text -- Android should have the correct font family 4`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {

--- a/packages/components/src/text/__tests__/__snapshots__/Text.ios.test.js.snap
+++ b/packages/components/src/text/__tests__/__snapshots__/Text.ios.test.js.snap
@@ -5,7 +5,6 @@ exports[`Text -- iOS should have the correct font family 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -23,7 +22,6 @@ exports[`Text -- iOS should have the correct font family 2`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -44,7 +42,6 @@ exports[`Text -- iOS should have the correct font family 3`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -65,7 +62,6 @@ exports[`Text -- iOS should have the correct font family 4`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {

--- a/packages/components/src/timelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
+++ b/packages/components/src/timelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
@@ -55,7 +55,6 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
       style={
         Array [
           Object {
-            "fontFamily": "Roboto",
             "margin": 0,
           },
           Object {

--- a/packages/universal-components/package.json
+++ b/packages/universal-components/package.json
@@ -36,7 +36,10 @@
     "react-native-modal": "^7.0.2",
     "react-native-multi-slider": "https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e",
     "react-native-status-bar-height": "^2.2.0",
-    "styled-components": "^4.1.3"
+    "styled-components": "^4.1.3",
+    "memoize-one": "^5.0.0",
+    "react-fast-compare": "^2.0.4"
+
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",

--- a/packages/universal-components/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`Button - native should match snapshot diff 1`] = `
       }
     >
       <View
-@@ -35,35 +35,127 @@
+@@ -35,14 +35,14 @@
               \\"paddingHorizontal\\": 8,
               \\"paddingVertical\\": 11,
             },
@@ -35,14 +35,12 @@ exports[`Button - native should match snapshot diff 1`] = `
           ]
         }
       >
-        <View
-          style={
-            Object {
+@@ -52,18 +52,112 @@
               \\"alignItems\\": \\"center\\",
               \\"flexDirection\\": \\"row\\",
-+           }
+            }
           }
-+       >
+        >
 +         <View
 +           style={
 +             Object {
@@ -67,8 +65,8 @@ exports[`Button - native should match snapshot diff 1`] = `
 +                 },
 +                 undefined,
 +               ]
-              }
-            >
++             }
++           >
 +             f
 +           </Text>
 +         </View>
@@ -95,7 +93,6 @@ exports[`Button - native should match snapshot diff 1`] = `
 +             style={
 +               Array [
 +                 Object {
-+                   \\"fontFamily\\": \\"Roboto\\",
 +                   \\"margin\\": 0,
 +                 },
 +                 Array [
@@ -110,6 +107,9 @@ exports[`Button - native should match snapshot diff 1`] = `
 +                   },
 +                   undefined,
 +                 ],
++                 Object {
++                   \\"fontFamily\\": \\"Roboto\\",
++                 },
 +               ]
 +             }
 +           >

--- a/packages/universal-components/src/FilterButton/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/FilterButton/__tests__/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`FilterButton should match snapshot diff between active and inactive inp
 -           },
 +           false,
           ],
-@@ -60,6 +58,4 @@
+@@ -59,6 +57,4 @@
                   \\"paddingVertical\\": 4,
 -               },
 -               Object {

--- a/packages/universal-components/src/Icon/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Icon/__tests__/__snapshots__/index.test.js.snap
@@ -5,7 +5,6 @@ exports[`Icon renders a question mark if the icon name is invalid 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Array [
@@ -20,6 +19,9 @@ exports[`Icon renders a question mark if the icon name is invalid 1`] = `
         },
         undefined,
       ],
+      Object {
+        "fontFamily": "Roboto",
+      },
     ]
   }
 >

--- a/packages/universal-components/src/MenuGroup/__tests__/__snapshots__/MenuItem.android.test.js.snap
+++ b/packages/universal-components/src/MenuGroup/__tests__/__snapshots__/MenuItem.android.test.js.snap
@@ -28,13 +28,12 @@ exports[`MenuGroup renders correctly 1`] = `
         }
       >
         <Component>
-          <Text
-            expo={false}
+          <WithTheme
             size="large"
             type="attention"
           >
             test
-          </Text>
+          </WithTheme>
         </Component>
       </Component>
     </MenuItemWrapper>

--- a/packages/universal-components/src/MenuGroup/__tests__/__snapshots__/MenuItem.ios.test.js.snap
+++ b/packages/universal-components/src/MenuGroup/__tests__/__snapshots__/MenuItem.ios.test.js.snap
@@ -29,13 +29,12 @@ exports[`MenuGroup hides actionIcon 1`] = `
         }
       >
         <Component>
-          <Text
-            expo={false}
+          <WithTheme
             size="large"
             type="attention"
           >
             test
-          </Text>
+          </WithTheme>
         </Component>
       </Component>
     </MenuItemWrapper>
@@ -72,13 +71,12 @@ exports[`MenuGroup renders correctly 1`] = `
         }
       >
         <Component>
-          <Text
-            expo={false}
+          <WithTheme
             size="large"
             type="attention"
           >
             test
-          </Text>
+          </WithTheme>
         </Component>
         <Component
           style={

--- a/packages/universal-components/src/MenuGroup/__tests__/__snapshots__/MenuItem.test.js.snap
+++ b/packages/universal-components/src/MenuGroup/__tests__/__snapshots__/MenuItem.test.js.snap
@@ -42,13 +42,12 @@ exports[`MenuGroup renders with icon 1`] = `
           }
         />
         <Component>
-          <Text
-            expo={false}
+          <WithTheme
             size="large"
             type="attention"
           >
             test
-          </Text>
+          </WithTheme>
         </Component>
         <Component
           style={
@@ -98,20 +97,18 @@ exports[`MenuGroup renders with label 1`] = `
         }
       >
         <Component>
-          <Text
-            expo={false}
+          <WithTheme
             size="small"
             type="secondary"
           >
             label
-          </Text>
-          <Text
-            expo={false}
+          </WithTheme>
+          <WithTheme
             size="large"
             type="attention"
           >
             test
-          </Text>
+          </WithTheme>
         </Component>
         <Component
           style={
@@ -161,20 +158,18 @@ exports[`MenuGroup renders with subTitle 1`] = `
         }
       >
         <Component>
-          <Text
-            expo={false}
+          <WithTheme
             size="large"
             type="attention"
           >
             test
-          </Text>
-          <Text
-            expo={false}
+          </WithTheme>
+          <WithTheme
             size="small"
             type="secondary"
           >
             sub
-          </Text>
+          </WithTheme>
         </Component>
         <Component
           style={

--- a/packages/universal-components/src/Modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/universal-components/src/Modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -73,8 +73,10 @@ exports[`Modal - native should match snapshot 1`] = `
       style={
         Array [
           Object {
-            "fontFamily": "Roboto",
             "margin": 0,
+          },
+          Object {
+            "fontFamily": "Roboto",
           },
         ]
       }

--- a/packages/universal-components/src/PickerButton/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/PickerButton/__tests__/__snapshots__/index.test.js.snap
@@ -39,7 +39,7 @@ exports[`PickerButton should match snapshot diff 1`] = `
             \\"borderRadius\\": 6,
             \\"flex\\": 1,
             \\"flexBasis\\": 44,
-@@ -22,18 +47,18 @@
+@@ -21,21 +46,21 @@
               },
               Array [
                 Object {
@@ -51,6 +51,9 @@ exports[`PickerButton should match snapshot diff 1`] = `
                 },
 +               false,
               ],
+              Object {
+                \\"fontFamily\\": \\"Roboto\\",
+              },
             ]
           }
 -   />
@@ -62,7 +65,7 @@ exports[`PickerButton should match snapshot diff 1`] = `
             Array [
               Object {
                 \\"fontFamily\\": \\"orbit-icons\\",
-@@ -49,8 +74,10 @@
+@@ -51,8 +76,10 @@
               },
               undefined,
             ]

--- a/packages/universal-components/src/RadioButton/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/RadioButton/__tests__/__snapshots__/index.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`RadioButton should match snapshot diff 1`] = `
 "Snapshot Diff:
-- <RadioButton onPress={[Function mockConstructor]}><Text expo={false}>child-label</Text></RadioButton>
-+ <RadioButton bulletPosition=\\"left\\" checked={true} disabled={false} onPress={[Function mockConstructor]} style={{\\"padding\\": 10}} type=\\"bullet\\"><Text expo={false}>child-label</Text></RadioButton>
+- <RadioButton onPress={[Function mockConstructor]}><WithTheme>child-label</WithTheme></RadioButton>
++ <RadioButton bulletPosition=\\"left\\" checked={true} disabled={false} onPress={[Function mockConstructor]} style={{\\"padding\\": 10}} type=\\"bullet\\"><WithTheme>child-label</WithTheme></RadioButton>
 
 @@ -9,12 +9,14 @@
     style={
@@ -52,5 +52,5 @@ exports[`RadioButton should match snapshot diff 1`] = `
       style={
         Array [
           Object {
-            \\"fontFamily\\": \\"Roboto\\","
+            \\"margin\\": 0,"
 `;

--- a/packages/universal-components/src/Rating/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Rating/__tests__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`Rating should match snapshot diff 1`] = `
 - <Rating />
 + <Rating rating={3} style={{\\"color\\": \\"#ffb100\\"}} />
 
-@@ -7,12 +7,14 @@
+@@ -6,15 +6,17 @@
         },
         Array [
           Object {
@@ -16,6 +16,9 @@ exports[`Rating should match snapshot diff 1`] = `
 +           \\"color\\": \\"#ffb100\\",
 +         },
         ],
+        Object {
+          \\"fontFamily\\": \\"Roboto\\",
+        },
       ]
     }
   >

--- a/packages/universal-components/src/Stepper/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Stepper/__tests__/__snapshots__/index.test.js.snap
@@ -5,14 +5,16 @@ exports[`Stepper should match snapshot diff between small and normal input 1`] =
 - <Stepper number={0} onDecrement={[Function mockConstructor]} onIncrement={[Function mockConstructor]} />
 + <Stepper number={0} onDecrement={[Function mockConstructor]} onIncrement={[Function mockConstructor]} showNumber={false} />
 
-@@ -73,14 +73,2 @@
+@@ -73,16 +73,2 @@
     </View>
 -   <Text
 -     style={
 -       Array [
 -         Object {
--           \\"fontFamily\\": \\"Roboto\\",
 -           \\"margin\\": 0,
+-         },
+-         Object {
+-           \\"fontFamily\\": \\"Roboto\\",
 -         },
 -       ]
 -     }
@@ -42,8 +44,7 @@ exports[`Stepper should match the snapshot 1`] = `
     onPress={[MockFunction]}
     touchable={true}
   />
-  <Text
-    expo={false}
+  <WithTheme
     style={
       Object {
         "fontSize": 16,
@@ -52,7 +53,7 @@ exports[`Stepper should match the snapshot 1`] = `
     }
   >
     0
-  </Text>
+  </WithTheme>
   <StepperButton
     icon={
       <Icon

--- a/packages/universal-components/src/Text/Text.js
+++ b/packages/universal-components/src/Text/Text.js
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import { Text as RNText, Platform } from 'react-native';
-import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { StyleSheet } from '../PlatformStyleSheet';
 import { createStylesGenerator } from '../utils';
@@ -13,6 +12,7 @@ import {
   textColor,
 } from './styles';
 import type { TextType } from './TextTypes';
+import { withTheme } from '../ThemeProvider';
 
 const colorGen = createStylesGenerator('color', textColor);
 const fontWeightGen = createStylesGenerator('fontWeight', fontWeightTypes);
@@ -31,6 +31,7 @@ const Text = ({
   uppercase,
   weight,
   expo,
+  theme,
 }: TextType) => {
   const textStyle = [styles.text];
   if (italic) {
@@ -55,17 +56,17 @@ const Text = ({
     textStyle.push(style);
   }
 
+  let fontFamily = theme.styles.normalFontFamily;
   if (expo && (Platform.OS === 'ios' || Platform.OS === 'android')) {
-    let fontFamily = styles.normalFontFamily;
     if (italic && weight === 'bold') {
-      fontFamily = styles.boldItalicFontFamily;
+      fontFamily = theme.styles.boldItalicFontFamily;
     } else if (italic) {
-      fontFamily = styles.italicFontFamily;
+      fontFamily = theme.styles.italicFontFamily;
     } else if (weight === 'bold') {
-      fontFamily = styles.boldFontFamily;
+      fontFamily = theme.styles.boldFontFamily;
     }
-    textStyle.push(fontFamily);
   }
+  textStyle.push(fontFamily);
 
   return (
     <RNText
@@ -85,7 +86,6 @@ Text.defaultProps = {
 const styles = StyleSheet.create({
   text: {
     margin: 0,
-    fontFamily: Platform.OS === 'web' ? defaultTokens.fontFamily : 'Roboto',
   },
   italic: {
     fontStyle: 'italic',
@@ -97,18 +97,6 @@ const styles = StyleSheet.create({
   ...alignGen(),
   ...colorGen(),
   ...fontSizeGen(),
-  normalFontFamily: {
-    fontFamily: 'Roboto',
-  },
-  boldFontFamily: {
-    fontFamily: 'RobotoBold',
-  },
-  italicFontFamily: {
-    fontFamily: 'RobotoItalic',
-  },
-  boldItalicFontFamily: {
-    fontFamily: 'RobotoBoldItalic',
-  },
 });
 
-export default Text;
+export default withTheme(Text);

--- a/packages/universal-components/src/Text/TextTypes.js
+++ b/packages/universal-components/src/Text/TextTypes.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { type StylePropType } from '../PlatformStyleSheet/StyleTypes';
+import { type Theme } from '../ThemeProvider';
 
 export type TextType = {|
   align?: 'left' | 'right' | 'center' | 'justify',
@@ -24,4 +25,5 @@ export type TextType = {|
     | 'white',
   +weight?: 'normal' | 'bold',
   +expo?: boolean,
+  +theme: Theme,
 |};

--- a/packages/universal-components/src/Text/__tests__/__snapshots__/Text.android.test.js.snap
+++ b/packages/universal-components/src/Text/__tests__/__snapshots__/Text.android.test.js.snap
@@ -5,7 +5,6 @@ exports[`Text -- Android should have the correct font family -- EXPO 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -23,7 +22,6 @@ exports[`Text -- Android should have the correct font family -- EXPO 2`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -44,7 +42,6 @@ exports[`Text -- Android should have the correct font family -- EXPO 3`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -65,7 +62,6 @@ exports[`Text -- Android should have the correct font family -- EXPO 4`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -89,7 +85,6 @@ exports[`Text -- Android should have the default font family 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -97,6 +92,9 @@ exports[`Text -- Android should have the default font family 1`] = `
       },
       Object {
         "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }

--- a/packages/universal-components/src/Text/__tests__/__snapshots__/Text.ios.test.js.snap
+++ b/packages/universal-components/src/Text/__tests__/__snapshots__/Text.ios.test.js.snap
@@ -5,7 +5,6 @@ exports[`Text -- iOS should have the correct font family -- EXPO 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -23,7 +22,6 @@ exports[`Text -- iOS should have the correct font family -- EXPO 2`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -44,7 +42,6 @@ exports[`Text -- iOS should have the correct font family -- EXPO 3`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -65,7 +62,6 @@ exports[`Text -- iOS should have the correct font family -- EXPO 4`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -89,7 +85,6 @@ exports[`Text -- iOS should have the default font family 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -97,6 +92,9 @@ exports[`Text -- iOS should have the default font family 1`] = `
       },
       Object {
         "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }

--- a/packages/universal-components/src/Text/__tests__/__snapshots__/Text.web.test.js.snap
+++ b/packages/universal-components/src/Text/__tests__/__snapshots__/Text.web.test.js.snap
@@ -5,7 +5,6 @@ exports[`Text -- Web should have the correct font family 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -13,6 +12,9 @@ exports[`Text -- Web should have the correct font family 1`] = `
       },
       Object {
         "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }
@@ -26,8 +28,10 @@ exports[`Text -- Web should have the default font family -- EXPO 1`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }
@@ -41,11 +45,13 @@ exports[`Text -- Web should have the default font family -- EXPO 2`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
         "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }
@@ -59,11 +65,13 @@ exports[`Text -- Web should have the default font family -- EXPO 3`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
         "fontStyle": "italic",
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }
@@ -77,7 +85,6 @@ exports[`Text -- Web should have the default font family -- EXPO 4`] = `
   style={
     Array [
       Object {
-        "fontFamily": "Roboto",
         "margin": 0,
       },
       Object {
@@ -85,6 +92,9 @@ exports[`Text -- Web should have the default font family -- EXPO 4`] = `
       },
       Object {
         "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "Roboto",
       },
     ]
   }

--- a/packages/universal-components/src/Text/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Text/__tests__/__snapshots__/index.test.js.snap
@@ -8,10 +8,9 @@ exports[`Text should match snapshot diff 1`] = `
 @@ -3,10 +3,28 @@
       Array [
         Object {
-          \\"fontFamily\\": \\"Roboto\\",
           \\"margin\\": 0,
         },
-+       Object {
+        Object {
 +         \\"fontStyle\\": \\"italic\\",
 +       },
 +       Object {
@@ -29,9 +28,10 @@ exports[`Text should match snapshot diff 1`] = `
 +       Object {
 +         \\"textAlign\\": \\"center\\",
 +       },
++       Object {
+          \\"fontFamily\\": \\"Roboto\\",
+        },
       ]
     }
-  >
-    Lorem ipsum
-  </Text>"
+  >"
 `;

--- a/packages/universal-components/src/TextInput/TextInput.js
+++ b/packages/universal-components/src/TextInput/TextInput.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
+import { withTheme } from '../ThemeProvider';
 import { Text } from '../Text';
 import { FormLabel } from '../FormLabel';
 import { Icon } from '../Icon';
@@ -165,6 +166,7 @@ class TextInput extends React.Component<Props, State> {
       status = 'default',
       autoFocus,
       autoCorrect = true,
+      theme,
     } = this.props;
     const { focused, value } = this.state;
 
@@ -240,6 +242,7 @@ class TextInput extends React.Component<Props, State> {
               maxLength={maxLength}
               minLength={minLength}
               style={[
+                theme.styles.normalFontFamily,
                 styles.inputField,
                 disabled && styles.inputFieldDisabled,
                 ifSuccess && styles.inputFieldSuccess,
@@ -304,7 +307,6 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     padding: 0,
-    fontFamily: 'Roboto',
     web: {
       outline: 'none',
       color: defaultTokens.colorTextInput,
@@ -352,4 +354,4 @@ const styles = StyleSheet.create({
   ...heightGen(),
 });
 
-export default TextInput;
+export default withTheme(TextInput);

--- a/packages/universal-components/src/TextInput/TextInputTypes.js
+++ b/packages/universal-components/src/TextInput/TextInputTypes.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { type StylePropType } from '../PlatformStyleSheet';
+import { type Theme } from '../ThemeProvider';
 
 export type Props = {|
   +autoCorrect?: boolean,
@@ -27,6 +28,7 @@ export type Props = {|
   +status?: 'default' | 'success' | 'warning', // this prop is supported only on mobile
   +labelContainerStyle?: StylePropType,
   +style?: StylePropType,
+  +theme: Theme,
 |};
 
 export type State = {|

--- a/packages/universal-components/src/TextInput/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/TextInput/__tests__/__snapshots__/index.test.js.snap
@@ -2,15 +2,15 @@
 
 exports[`TextInput should match snapshot diff between small and normal input 1`] = `
 "Snapshot Diff:
-- <TextInput label=\\"Label\\" />
-+ <TextInput label=\\"Label\\" size=\\"small\\" />
+- <WithTheme label=\\"Label\\" />
++ <WithTheme label=\\"Label\\" size=\\"small\\" />
 
-@@ -51,3 +51,3 @@
+@@ -53,3 +53,3 @@
           Object {
 -           \\"height\\": 44,
 +           \\"height\\": 32,
           },
-@@ -86,3 +86,3 @@
+@@ -90,3 +90,3 @@
             Object {
 -             \\"height\\": 44,
 +             \\"height\\": 32,
@@ -22,7 +22,7 @@ exports[`TextInput should render a custom input and match diff snapshot with uns
 - First value
 + Second value
 
-@@ -54,13 +54,11 @@
+@@ -56,13 +56,11 @@
           undefined,
           false,
           undefined,

--- a/packages/universal-components/src/ThemeProvider/ThemeHelpers.js
+++ b/packages/universal-components/src/ThemeProvider/ThemeHelpers.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { StyleSheet } from '../PlatformStyleSheet';
+import type { Tokens, Theme } from './ThemeProvider';
+
+export const createTheme = (tokens: Tokens): Theme => {
+  return {
+    tokens: {
+      ...tokens,
+    },
+    styles: StyleSheet.create({
+      normalFontFamily: {
+        fontFamily: tokens.fontFamilyNormal,
+      },
+      boldFontFamily: {
+        fontFamily: tokens.fontFamilyBold,
+      },
+      italicFontFamily: {
+        fontFamily: tokens.fontFamilyItalic,
+      },
+      boldItalicFontFamily: {
+        fontFamily: tokens.fontFamilyBoldItalic,
+      },
+    }),
+  };
+};

--- a/packages/universal-components/src/ThemeProvider/ThemeProvider.js
+++ b/packages/universal-components/src/ThemeProvider/ThemeProvider.js
@@ -1,0 +1,73 @@
+// @flow
+
+import * as React from 'react';
+import memoize from 'memoize-one';
+import isEqual from 'react-fast-compare';
+
+import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
+import { createTheme } from './ThemeHelpers';
+
+export type Tokens = {|
+  fontFamilyNormal?: string,
+  fontFamilyBold?: string,
+  fontFamilyItalic?: string,
+  fontFamilyBoldItalic?: string,
+|};
+
+export type Styles = {
+  +normalFontFamily?: StylePropType,
+  +boldFontFamily?: StylePropType,
+  +italicFontFamily?: StylePropType,
+  +boldItalicFontFamily?: StylePropType,
+};
+
+export type Theme = {|
+  tokens: Tokens,
+  styles: Styles,
+|};
+
+type Props = {|
+  +children?: React.Node,
+  +tokens?: Tokens,
+|};
+
+const defaultTokens = {
+  fontFamilyNormal: 'Roboto',
+  fontFamilyBold: 'RobotoBold',
+  fontFamilyItalic: 'RobotoItalic',
+  fontFamilyBoldItalic: 'RobotoBoldItalic',
+};
+
+const { Provider, Consumer } = React.createContext<Theme>(
+  createTheme(defaultTokens),
+);
+
+export default class ThemeProvider extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    this.getStyles = memoize(tokens => {
+      return createTheme({
+        ...defaultTokens,
+        ...(tokens ?? {}),
+      });
+    }, isEqual);
+  }
+
+  getStyles: (?Tokens) => Theme;
+
+  render() {
+    return (
+      <Provider value={this.getStyles(this.props.tokens)}>
+        {this.props.children}
+      </Provider>
+    );
+  }
+}
+
+export const withTheme = (Component: React.ElementType) => {
+  const WithTheme = (props: Object) => (
+    <Consumer>{theme => <Component {...props} theme={theme} />}</Consumer>
+  );
+  return WithTheme;
+};

--- a/packages/universal-components/src/ThemeProvider/ThemeProvider.stories.js
+++ b/packages/universal-components/src/ThemeProvider/ThemeProvider.stories.js
@@ -1,0 +1,34 @@
+// @flow
+
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { select, withKnobs } from '@storybook/addon-knobs';
+
+import { Text } from '../Text';
+
+import { ThemeProvider } from '.';
+
+const style = {
+  flex: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: 25,
+  backgroundColor: '#f5fcff',
+};
+const customText = 'Lorem ipsum dolor sit amet';
+
+storiesOf('ThemeProvider', module)
+  .addDecorator(withKnobs)
+  .addDecorator(getStory => <View style={style}>{getStory()}</View>)
+  .add('Playground', () => {
+    const fontFamily = select('Font family', ['Roboto', 'Georgia'], 'Roboto');
+
+    return (
+      <ThemeProvider tokens={{ fontFamilyNormal: fontFamily }}>
+        <Text size="large" type="primary">
+          {customText}
+        </Text>
+      </ThemeProvider>
+    );
+  });

--- a/packages/universal-components/src/ThemeProvider/index.js
+++ b/packages/universal-components/src/ThemeProvider/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+export { default as ThemeProvider } from './ThemeProvider';
+export { withTheme } from './ThemeProvider';
+export type { Theme } from './ThemeProvider';

--- a/packages/universal-components/src/Tooltip/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Tooltip/__tests__/__snapshots__/index.test.js.snap
@@ -64,8 +64,7 @@ exports[`TooltipBubble should match the snapshot 1`] = `
       ]
     }
   >
-    <Text
-      expo={false}
+    <WithTheme
       style={
         Object {
           "color": "#fff",
@@ -75,7 +74,7 @@ exports[`TooltipBubble should match the snapshot 1`] = `
       }
     >
       Hello Kiwi.com
-    </Text>
+    </WithTheme>
   </Component>
 </Component>
 `;

--- a/packages/universal-components/src/index.js
+++ b/packages/universal-components/src/index.js
@@ -40,9 +40,11 @@ export { PickerButton } from './PickerButton';
 
 /* Utils */
 export { StyleSheet } from './PlatformStyleSheet';
+export { ThemeProvider, withTheme } from './ThemeProvider';
 
 /* Types */
 export type { IconNameType } from './types/_generated-types';
+export type { Theme } from './ThemeProvider';
 
 export type {
   StylePropType,


### PR DESCRIPTION
Summary: Created initial setup for theming. Current implementation allows global font family change.

The idea behind having separate `tokens` and `styles` inside theme prop is to prevent unnecessary usage of dynamic styles and rebuilding styles with every render (especially for texts). Currently `fontFamily` styles are only updated with `ThemeProvider` props change (for example if some kind of theme switch will be implemented).

Note: Tests are currently failing because changes in `Text` component broke about fifty snapshots 🤕 . So to keep PR readable I will update all the affected snapshots before merge, after we approve the core idea.

<img width="435" alt="Screenshot 2019-03-19 at 13 03 49" src="https://user-images.githubusercontent.com/2660330/54622786-7f0c1d80-4a6a-11e9-85f0-400a9474f1a6.png">