### PR TITLE
Chore: No automatic push to GitHub

### DIFF
--- a/packages/universal-components/.release-it.json
+++ b/packages/universal-components/.release-it.json
@@ -1,17 +1,8 @@
 {
-  "increment": "conventional:angular",
   "scripts": {
     "beforeStage": "yarn build"
   },
-  "git": {
-    "commitMessage": "chore: release %s",
-    "tag": false
-  },
   "npm": {
     "publish": true
-  },
-  "github": {
-    "release": false
-  },
-  "access": "public"
+  }
 }

--- a/packages/universal-components/package.json
+++ b/packages/universal-components/package.json
@@ -9,7 +9,7 @@
     "storybook:build": "rimraf storybook-static; build-storybook -c storybook -s ./fonts",
     "storybook:mobile": "yarn workspace @kiwicom/margarita-mobile-storybook start:universal-components",
     "prerelease": "node scripts/preparePackageJson.js",
-    "release": "release-it",
+    "release": "release-it --no-git",
     "postrelease": "node scripts/cleanPackageJson.js",
     "build": "rimraf lib && yarn build:generate-icon-types && yarn build:copy:web && yarn build:copy:native && yarn build:copy:flow && yarn build:copy:fonts && yarn build:lib",
     "build:generate-icon-types": "node ./scripts/generateTypes.js",


### PR DESCRIPTION
Summary: By pushing to GitHub during NPM publishing, the `package.json`'s "main" entrypoint point to `lib/web/index.js` and not `src/index.js`, which is not what we want. The adjusted release-it config and release-it command prevents commiting, pushing and tagging.
That also means we will need to manually commit the updated version to the repo. To be improved further.