### PR TITLE
Fix: Moved design tokens to universal-components

### DIFF
--- a/apps/core/components/ItineraryCard/FlightTimes.js
+++ b/apps/core/components/ItineraryCard/FlightTimes.js
@@ -3,8 +3,7 @@
 import * as React from 'react';
 import { View, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
-import { StyleSheet, Text } from '@kiwicom/universal-components';
+import { StyleSheet, Text, designTokens } from '@kiwicom/universal-components';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 
 import type { FlightTimes_data as FlightTimesType } from './__generated__/FlightTimes_data.graphql';
@@ -35,8 +34,8 @@ const styles = StyleSheet.create({
     color: defaultTokens.colorTextAttention,
     padding: 5,
     web: {
-      fontWeight: margaritaTokens.fontWeightMedium,
-      color: margaritaTokens.paletteBlueDark,
+      fontWeight: designTokens.fontWeightMedium,
+      color: designTokens.paletteBlueDark,
       padding: 0,
       lineHeight: 17,
     },

--- a/apps/core/components/ItineraryCard/ItineraryCard.js
+++ b/apps/core/components/ItineraryCard/ItineraryCard.js
@@ -6,8 +6,12 @@ import { formatPrice } from '@kiwicom/margarita-utils';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { TouchableWithoutFeedback } from '@kiwicom/margarita-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
-import { StyleSheet, Hoverable, Card } from '@kiwicom/universal-components';
+import {
+  StyleSheet,
+  Hoverable,
+  Card,
+  designTokens,
+} from '@kiwicom/universal-components';
 
 import RenderTripSectorItem from './RenderTripSectorItem';
 import ItineraryCardWrapper from './ItineraryCardWrapper';
@@ -141,7 +145,7 @@ const styles = StyleSheet.create({
     web: {
       alignSelf: 'center',
       width: '100%',
-      maxWidth: margaritaTokens.widthScreenNormal,
+      maxWidth: designTokens.widthScreenNormal,
       marginBottom: parseInt(defaultTokens.spaceMedium, 10),
       borderRadius: parseInt(defaultTokens.borderRadiusNormal, 10),
       boxShadow: '0 2px 4px 0 rgba(23,27,30,.1)',

--- a/apps/core/components/ItineraryCard/ItineraryCardWrapper.web.js
+++ b/apps/core/components/ItineraryCard/ItineraryCardWrapper.web.js
@@ -3,12 +3,12 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import {
   StyleSheet,
   Icon,
   LocalizedPrice,
   Button,
+  designTokens,
 } from '@kiwicom/universal-components';
 import {
   withLayoutContext,
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     borderStyle: 'dotted',
-    borderColor: margaritaTokens.borderColorInkLight,
+    borderColor: designTokens.borderColorInkLight,
     borderTopWidth: parseInt(defaultTokens.borderWidthCard, 10),
   },
 });

--- a/apps/core/components/ItineraryCard/StopoverDurationWrapper.web.js
+++ b/apps/core/components/ItineraryCard/StopoverDurationWrapper.web.js
@@ -1,10 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { StyleSheet, Text } from '@kiwicom/universal-components';
+import { StyleSheet, Text, designTokens } from '@kiwicom/universal-components';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 type Props = {|
   +children: React.Node,
@@ -28,13 +27,13 @@ const styles = StyleSheet.create({
   },
   dottedLine: {
     borderStyle: 'dotted',
-    borderColor: margaritaTokens.borderColorInkLight,
+    borderColor: designTokens.borderColorInkLight,
     borderBottomWidth: 1,
     width: parseInt(defaultTokens.widthIconLarge, 10),
     marginEnd: 30,
   },
   stopoverText: {
-    color: margaritaTokens.borderColorInkNormal,
+    color: designTokens.borderColorInkNormal,
     fontSize: parseInt(defaultTokens.fontSizeTextSmall, 10),
   },
 });

--- a/apps/core/components/ItineraryCard/TripSector.js
+++ b/apps/core/components/ItineraryCard/TripSector.js
@@ -3,9 +3,8 @@
 import * as React from 'react';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { View, Platform } from 'react-native';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, designTokens } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import {
   withLayoutContext,
   LAYOUT,
@@ -138,7 +137,7 @@ const styles = StyleSheet.create({
   dateText: {
     web: {
       fontSize: parseFloat(defaultTokens.fontSizeTextNormal),
-      color: margaritaTokens.paletteBlueDark,
+      color: designTokens.paletteBlueDark,
     },
   },
   durationText: {

--- a/apps/core/components/ItineraryCard/itineraryDetail/ItineraryDetailWrapper.web.js
+++ b/apps/core/components/ItineraryCard/itineraryDetail/ItineraryDetailWrapper.web.js
@@ -2,9 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, designTokens } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import type { Props } from './ItineraryDetailWrapperTypes';
 
@@ -14,7 +13,7 @@ export default function ItineraryDetailWrapper({ children }: Props) {
 
 const styles = StyleSheet.create({
   container: {
-    borderColor: margaritaTokens.borderColorInkLight,
+    borderColor: designTokens.borderColorInkLight,
     borderTopWidth: parseInt(defaultTokens.borderWidthCard, 10),
   },
 });

--- a/apps/core/components/priceSummary/PriceSummary.js
+++ b/apps/core/components/priceSummary/PriceSummary.js
@@ -2,10 +2,13 @@
 
 import * as React from 'react';
 import { Animated, View } from 'react-native';
-import { StyleSheet, Button } from '@kiwicom/universal-components';
+import {
+  StyleSheet,
+  Button,
+  designTokens,
+} from '@kiwicom/universal-components';
 import { TouchableWithoutFeedback } from '@kiwicom/margarita-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import Expander from './Expander';
 
@@ -128,7 +131,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     start: 0,
     end: 0,
-    backgroundColor: margaritaTokens.backdropColor,
+    backgroundColor: designTokens.backdropColor,
   },
   container: {
     backgroundColor: defaultTokens.backgroundCard,

--- a/apps/core/components/sectorDetail/SectorHeader.js
+++ b/apps/core/components/sectorDetail/SectorHeader.js
@@ -1,10 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, designTokens } from '@kiwicom/universal-components';
 import { Text, Duration } from '@kiwicom/margarita-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import { View } from 'react-native';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 
@@ -46,7 +45,7 @@ const styles = StyleSheet.create({
     fontSize: parseInt(defaultTokens.fontSizeHeadingTitle3, 10),
     color: defaultTokens.colorTextSecondary,
     web: {
-      fontWeight: margaritaTokens.fontWeightMedium,
+      fontWeight: designTokens.fontWeightMedium,
     },
   },
 });

--- a/apps/core/components/sectorDetail/segment/SegmentStopInfoRow.js
+++ b/apps/core/components/sectorDetail/segment/SegmentStopInfoRow.js
@@ -5,11 +5,11 @@ import { View } from 'react-native';
 import {
   Icon,
   StyleSheet,
+  designTokens,
   type IconNameType,
 } from '@kiwicom/universal-components';
 import { Text } from '@kiwicom/margarita-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 type Props = {|
   +iconName: IconNameType,
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
   },
   infoTextThick: {
     web: {
-      fontWeight: margaritaTokens.fontWeightMedium,
+      fontWeight: designTokens.fontWeightMedium,
     },
   },
   infoLabel: {

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -10,7 +10,6 @@
     "@kiwicom/margarita-navigation": "^0.0.0",
     "@kiwicom/margarita-relay": "^0",
     "@kiwicom/margarita-utils": "^0",
-    "@kiwicom/margarita-design-tokens": "^0",
     "@kiwicom/orbit-design-tokens": "^0.3.0",
     "@kiwicom/universal-components": "0.0.14",
     "geolib": "^2.0.24",

--- a/apps/core/scenes/passengerForm/PassengerForm.js
+++ b/apps/core/scenes/passengerForm/PassengerForm.js
@@ -7,9 +7,9 @@ import {
   SegmentedButton,
   Picker,
   TextInput,
+  designTokens,
 } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import { DateInput } from '@kiwicom/margarita-components';
 import { US_DATE_FORMAT } from '@kiwicom/margarita-config';
 
@@ -137,7 +137,7 @@ const styles = StyleSheet.create({
     backgroundColor: defaultTokens.paletteWhite,
     width: '100%',
     web: {
-      maxWidth: margaritaTokens.widthScreenNormal,
+      maxWidth: designTokens.widthScreenNormal,
     },
   },
   inputLabel: {

--- a/apps/core/scenes/payment/Payment.js
+++ b/apps/core/scenes/payment/Payment.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, designTokens } from '@kiwicom/universal-components';
 import {
   TableRow,
   TableRowDivider,
@@ -13,7 +13,6 @@ import {
 } from '@kiwicom/margarita-components';
 import { withNavigation, type Navigation } from '@kiwicom/margarita-navigation';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import { PriceSummary } from '../../components/priceSummary';
 
@@ -155,7 +154,7 @@ const styles = StyleSheet.create({
   centeredContainer: {
     web: {
       alignSelf: 'center',
-      maxWidth: margaritaTokens.widthScreenNormal,
+      maxWidth: designTokens.widthScreenNormal,
       alignItems: 'flex-start',
     },
   },

--- a/apps/core/scenes/results/Results.js
+++ b/apps/core/scenes/results/Results.js
@@ -3,10 +3,9 @@
 import * as React from 'react';
 import { SafeAreaView } from 'react-native';
 import { QueryRenderer, graphql } from '@kiwicom/margarita-relay';
-import { StyleSheet } from '@kiwicom/universal-components';
+import { StyleSheet, designTokens } from '@kiwicom/universal-components';
 import * as DateFNS from 'date-fns';
 import { SearchParamsSummary } from '@kiwicom/margarita-components';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import { ORDINAL_DAY_MONTH_FORMAT } from '@kiwicom/margarita-config';
 
 import type { ResultsQueryResponse } from './__generated__/ResultsQuery.graphql';
@@ -88,7 +87,7 @@ export default class Results extends React.Component<Props> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: margaritaTokens.heightStatusBar,
+    marginTop: designTokens.heightStatusBar,
     web: {
       marginTop: 0,
     },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -18,7 +18,6 @@ module.exports = withImages(
       '@kiwicom/margarita-navigation',
       '@kiwicom/margarita-config',
       '@kiwicom/margarita-map',
-      '@kiwicom/margarita-design-tokens',
     ],
     webpack: (config, { isServer }) => {
       // Bundle Analyzer

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@kiwicom/margarita-config": "^0",
-    "@kiwicom/margarita-design-tokens": "^0",
     "@kiwicom/margarita-utils": "^0",
     "@kiwicom/universal-components": "0.0.14",
     "@storybook/react-native": "^4.1.13",

--- a/packages/components/src/contentContainer/ContentContainer.js
+++ b/packages/components/src/contentContainer/ContentContainer.js
@@ -2,9 +2,12 @@
 
 import * as React from 'react';
 import { View, ScrollView } from 'react-native';
-import { StyleSheet, type StylePropType } from '@kiwicom/universal-components';
+import {
+  StyleSheet,
+  designTokens,
+  type StylePropType,
+} from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 type Props = {|
   +children: React.Node | React.ChildrenArray<React.Node>,
@@ -45,7 +48,7 @@ const styles = StyleSheet.create({
   innerContainer: {
     width: '100%',
     web: {
-      maxWidth: margaritaTokens.widthScreenNormal,
+      maxWidth: designTokens.widthScreenNormal,
     },
   },
 });

--- a/packages/components/src/tripInput/TripInput.js
+++ b/packages/components/src/tripInput/TripInput.js
@@ -3,10 +3,10 @@
 import * as React from 'react';
 import { View, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 import {
   StyleSheet,
   Icon,
+  designTokens,
   type StylePropType,
 } from '@kiwicom/universal-components';
 
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
     color: defaultTokens.colorTextAttention,
     web: {
       color: defaultTokens.paletteInkNormal,
-      fontWeight: margaritaTokens.fontWeightMedium,
+      fontWeight: designTokens.fontWeightMedium,
     },
   },
 });

--- a/packages/design-tokens/index.js
+++ b/packages/design-tokens/index.js
@@ -1,3 +1,0 @@
-// @flow
-
-export { margaritaTokens } from './src/MargaritaTokens';

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@kiwicom/margarita-design-tokens",
-  "version": "0.0.0",
-  "private": true,
-  "main": "index.js"
-}

--- a/packages/universal-components/package.json
+++ b/packages/universal-components/package.json
@@ -31,7 +31,6 @@
   "license": "MIT",
   "dependencies": {
     "@kiwicom/orbit-design-tokens": "^0.3.0",
-    "@kiwicom/margarita-design-tokens": "^0",
     "@storybook/react-native": "^4.1.13",
     "react-native-modal": "^7.0.2",
     "react-native-multi-slider": "https://github.com/kiwicom/react-native-multi-slider.git#beb71bf5eb210fed393cb29b18032105b725611e",

--- a/packages/universal-components/src/Badge/Badge.js
+++ b/packages/universal-components/src/Badge/Badge.js
@@ -3,10 +3,10 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
 import { Text } from '../Text';
 import { StyleSheet } from '../PlatformStyleSheet';
+import { designTokens } from '../DesignTokens';
 import type { BadgeProps, BadgeType } from './BadgeTypes';
 import { textColor, wrapperColor } from './styles';
 
@@ -49,8 +49,8 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: parseFloat(defaultTokens.fontSizeTextSmall),
-    lineHeight: margaritaTokens.heightBadge,
-    fontWeight: margaritaTokens.fontWeightMedium,
+    lineHeight: designTokens.heightBadge,
+    fontWeight: designTokens.fontWeightMedium,
     letterSpacing: 0.3,
     color: defaultTokens.colorTextBadgeDark,
   },

--- a/packages/universal-components/src/Badge/styles/index.js
+++ b/packages/universal-components/src/Badge/styles/index.js
@@ -1,7 +1,8 @@
 // @flow
 
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
+
+import { designTokens } from '../../DesignTokens';
 
 export const wrapperColor = {
   primary: defaultTokens.paletteProductNormal,
@@ -10,8 +11,8 @@ export const wrapperColor = {
   info: defaultTokens.backgroundBadgeInfo,
   neutral: defaultTokens.backgroundBadgeNeutral,
   success: defaultTokens.backgroundBadgeSuccess,
-  warning: margaritaTokens.backgroundBadgeWarning,
-  white: margaritaTokens.backgroundBadgeWhite,
+  warning: designTokens.backgroundBadgeWarning,
+  white: designTokens.backgroundBadgeWhite,
 };
 
 export const textColor = {
@@ -21,6 +22,6 @@ export const textColor = {
   info: defaultTokens.colorTextBadgeInfo,
   neutral: defaultTokens.colorTextBadgeNeutral,
   success: defaultTokens.colorTextBadgeSuccess,
-  warning: margaritaTokens.colorTextBadgeWarning,
-  white: margaritaTokens.colorTextBadgeWhite,
+  warning: designTokens.colorTextBadgeWarning,
+  white: designTokens.colorTextBadgeWhite,
 };

--- a/packages/universal-components/src/Checkbox/CheckboxText.js
+++ b/packages/universal-components/src/Checkbox/CheckboxText.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
+import { designTokens } from '../DesignTokens';
 import { Text } from '../Text';
 import { StyleSheet } from '../PlatformStyleSheet';
 
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
   },
   labelChecked: {
     web: {
-      fontWeight: margaritaTokens.fontWeightMedium,
+      fontWeight: designTokens.fontWeightMedium,
     },
   },
   info: {

--- a/packages/universal-components/src/DesignTokens/DesignTokens.js
+++ b/packages/universal-components/src/DesignTokens/DesignTokens.js
@@ -1,6 +1,6 @@
 // @flow
 
-export const margaritaTokens = {
+const designTokens = {
   widthScreenNormal: 720,
   heightStatusBar: 20,
   paletteBlueDark: '#2e353b',
@@ -15,3 +15,5 @@ export const margaritaTokens = {
   colorTextBadgeWarning: '#FFFFFF',
   colorTextBadgeWhite: '#7F91A8',
 };
+
+export default designTokens;

--- a/packages/universal-components/src/DesignTokens/index.js
+++ b/packages/universal-components/src/DesignTokens/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export { default as designTokens } from './DesignTokens';

--- a/packages/universal-components/src/FilterButton/FilterButton.js
+++ b/packages/universal-components/src/FilterButton/FilterButton.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
+import { designTokens } from '../DesignTokens';
 import { Text } from '../Text';
 import { Touchable } from '../Touchable';
 import { StyleSheet } from '../PlatformStyleSheet';
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     paddingVertical: 4,
-    fontWeight: margaritaTokens.fontWeightMedium,
+    fontWeight: designTokens.fontWeightMedium,
     color: defaultTokens.colorTextPrimary,
     fontSize: 12,
     lineHeight: 15,

--- a/packages/universal-components/src/FormFeedback/FormFeedback.js
+++ b/packages/universal-components/src/FormFeedback/FormFeedback.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
+import { designTokens } from '../DesignTokens';
 import { Text } from '../Text';
 import { StyleSheet } from '../PlatformStyleSheet';
 import type { Props } from './FormFeedbackTypes';
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     color: defaultTokens.colorTextSecondary,
   },
   error: {
-    fontWeight: margaritaTokens.fontWeightMedium,
+    fontWeight: designTokens.fontWeightMedium,
     color: defaultTokens.colorTextError,
   },
 });

--- a/packages/universal-components/src/LocalizedPrice/LocalizedPrice.js
+++ b/packages/universal-components/src/LocalizedPrice/LocalizedPrice.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { margaritaTokens } from '@kiwicom/margarita-design-tokens';
 
+import { designTokens } from '../DesignTokens';
 import { Text } from '../Text';
 import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     color: defaultTokens.colorTextLinkPrimary,
     fontSize: parseFloat(defaultTokens.fontSizeTextLarge),
     web: {
-      color: margaritaTokens.paletteBlueDark,
+      color: designTokens.paletteBlueDark,
       fontSize: 18,
     },
   },

--- a/packages/universal-components/src/index.js
+++ b/packages/universal-components/src/index.js
@@ -41,6 +41,7 @@ export { PickerButton } from './PickerButton';
 /* Utils */
 export { StyleSheet } from './PlatformStyleSheet';
 export { ThemeProvider, withTheme } from './ThemeProvider';
+export { designTokens } from './DesignTokens';
 
 /* Types */
 export type { IconNameType } from './types/_generated-types';


### PR DESCRIPTION
Summary: Removes publishing blocking internal Margarita dependency.

Closes: #582

Note: I was thinking about also keeping `margarita-design-tokens`. But at the end I've decided to remove it. It will be probably confusing to have three different tokens. And as we previously discussed, for now this file should only contain repeating but still universal values and not margarita specific stuff like `colorTextDepartureTime`. So it quite makes sense to have these values as part of the `universal-components`.