### PR TITLE
Fix: Margarita components web storybook loads universal-components co…

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,7 @@
     "@storybook/addon-links": "^4.1.13",
     "@storybook/addon-ondevice-knobs": "^4.1.13",
     "@storybook/react": "^4.1.13",
+    "babel-loader": "^8.0.5",
     "react-native-web-image-loader": "^0.0.7"
   },
   "peerDependencies": {

--- a/packages/components/storybook/webpack.config.js
+++ b/packages/components/storybook/webpack.config.js
@@ -4,6 +4,15 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /universal-components\/src\/.*\.js$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['babel-preset-expo'],
+          },
+        },
+      },
+      {
         test: /\.(png|jpe?g|gif)$/,
         use:
           'react-native-web-image-loader?name=[name].[ext]&scalings[@2x]=2&scalings[-3x]=3',


### PR DESCRIPTION
…rrectly

Summary: After switching the 'main' field in `package.json` to the source folder of `universal-components`, the web storybook for `margarita-components` stopped working as the files from `universal-components` were not transpiled anymore. This PR fixes that issue by transpiling files from `universal-components` when building the storybook.