### PR TITLE
Refactor: Duplicate types in Itinerary and Booking

### DIFF
--- a/apps/graphql/src/apps/booking/Booking.js
+++ b/apps/graphql/src/apps/booking/Booking.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { RouteStop, Sector } from '../common/CommonTypes';
+
 export type ApiRouteStop = {|
   +where: {|
     +code: string,
@@ -31,32 +33,6 @@ export type BookingApiResult = {|
 export type RouteStopTimeApi = {|
   +utc: ?number,
   +local: ?number,
-|};
-
-type RouteStopTime = {|
-  +utc: ?(number | string),
-  +local: ?(number | string),
-|};
-
-export type RouteStop = {|
-  +cityName: ?string,
-  +cityId: ?string,
-  +time: ?RouteStopTime,
-  +code: ?string,
-|};
-
-export type Segment = {|
-  +id: string,
-  +isReturn: boolean,
-  +departure: ?RouteStop,
-  +arrival: ?RouteStop,
-|};
-
-type Sector = {|
-  +departure: ?RouteStop,
-  +arrival: ?RouteStop,
-  +segments: $ReadOnlyArray<Segment>,
-  +duration?: number,
 |};
 
 export type TypeSpecificData = {|

--- a/apps/graphql/src/apps/booking/dataloaders/Bookings.js
+++ b/apps/graphql/src/apps/booking/dataloaders/Bookings.js
@@ -10,10 +10,9 @@ import type {
   ApiFlight,
   ApiRouteStop,
   TypeSpecificData,
-  Segment,
   Passenger,
-  RouteStop,
 } from '../Booking';
+import type { RouteStop, Segment } from '../../common/CommonTypes';
 
 const cabinBag = '55x40x20, 10kg';
 const personalItem = '35x20x20';
@@ -95,7 +94,7 @@ const sanitizeReturn = (booking: BookingApiResult) => {
   const segments = booking.flights.map(flight => {
     const segment = sanitizeFlight(flight);
 
-    if (segment.isReturn) {
+    if (flight.return) {
       inboundSegments.push(segment);
     } else {
       outboundSegments.push(segment);
@@ -170,10 +169,12 @@ const sanitizeMulticity = (booking: BookingApiResult) => {
 
 const sanitizeFlight = (flight: ApiFlight): Segment => {
   return {
-    isReturn: flight.return === 1,
     id: flight.id,
     departure: sanitizeRouteStop(flight.departure),
     arrival: sanitizeRouteStop(flight.arrival),
+    duration: null, // @TODO - calculate duration
+    transporter: null, // @TODO - map values
+    vehicle: null, // @TODO - map values
   };
 };
 
@@ -202,15 +203,14 @@ const detectType = (booking: BookingApiResult) => {
   return 'BookingOneWay';
 };
 
-const sanitizeRouteStop = (departureArrival: ?ApiRouteStop) => {
+const sanitizeRouteStop = (departureArrival: ?ApiRouteStop): ?RouteStop => {
   if (departureArrival == null) {
     return null;
   }
 
   return {
-    cityName: departureArrival.where.name,
-    cityId: departureArrival.where.city_id,
     code: departureArrival.where.code,
+    cityId: departureArrival.where.city_id,
     time: {
       utc: departureArrival.when.utc,
       local: departureArrival.when.local,

--- a/apps/graphql/src/apps/common/CommonTypes.js
+++ b/apps/graphql/src/apps/common/CommonTypes.js
@@ -1,0 +1,43 @@
+// @flow
+
+export type DateType = {|
+  +local: ?(string | number),
+  +utc: ?(string | number),
+|};
+
+export type Price = {|
+  +amount: ?number,
+  +currency: ?string,
+|};
+
+export type RouteStop = {|
+  +cityId?: ?string,
+  +time: ?DateType,
+  +code: ?string,
+|};
+
+export type Sector = {|
+  +duration?: ?number,
+  +segments: ?Array<Segment>,
+  +stopoverDuration?: ?number,
+  +departure: ?RouteStop,
+  +arrival: ?RouteStop,
+|};
+
+export type Segment = {|
+  +id: ?string,
+  +transporter: ?Transporter,
+  +duration: ?number,
+  +vehicle: ?Vehicle,
+  +departure: ?RouteStop,
+  +arrival: ?RouteStop,
+|};
+
+export type Transporter = {|
+  +name: ?string,
+|};
+
+export type Vehicle = {|
+  +type: ?string,
+  +uniqueNo: ?string,
+|};

--- a/apps/graphql/src/apps/common/types/outputs/RouteStop.js
+++ b/apps/graphql/src/apps/common/types/outputs/RouteStop.js
@@ -4,7 +4,7 @@ import { GraphQLObjectType } from 'graphql';
 
 import GraphQLDateType from './DateType';
 import GraphQLLocation from '../../../location/types/outputs/Location';
-import type { RouteStop } from '../../../booking/Booking';
+import type { RouteStop } from '../../CommonTypes';
 import type { GraphqlContextType } from '../../../../services/graphqlContext/GraphQLContext';
 
 export default new GraphQLObjectType({

--- a/apps/graphql/src/apps/common/types/outputs/Sector.js
+++ b/apps/graphql/src/apps/common/types/outputs/Sector.js
@@ -2,7 +2,7 @@
 
 import { GraphQLObjectType, GraphQLInt, GraphQLList } from 'graphql';
 
-import type { Sector } from '../../../itinerary/Itinerary';
+import type { Sector } from '../../CommonTypes';
 import GraphQLBookingType from '../../../booking/types/enums/BookingType';
 import GraphQLSegment from './Segment';
 import GraphQLRouteStop from './RouteStop';
@@ -20,8 +20,7 @@ export default new GraphQLObjectType({
     },
     stopoverDuration: {
       type: GraphQLInt,
-      resolve: ({ stopoverDuration }: Sector): number | null =>
-        stopoverDuration,
+      resolve: ({ stopoverDuration }: Sector): ?number => stopoverDuration,
     },
     departure: {
       type: GraphQLRouteStop,

--- a/apps/graphql/src/apps/itinerary/Itinerary.js
+++ b/apps/graphql/src/apps/itinerary/Itinerary.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type { Location } from '../location/Location';
-import type { RouteStop } from '../booking/Booking';
+import type { RouteStop, Sector, Price } from '../common/CommonTypes';
 
 type Order = 'ASC' | 'DESC';
 type Sort = 'price' | 'duration' | 'quality' | 'date' | 'popularity';
@@ -48,58 +47,16 @@ export type ItineraryCheckParameters = {|
   +passengers: Passengers,
 |};
 
-export type Price = {|
-  +amount: ?number,
-  +currency: ?string,
-|};
-
-export type Time = {|
-  +local: ?(string | number),
-  +utc: ?(string | number),
-|};
-
-export type Transporter = {|
-  +name: ?string,
-|};
-
-export type Vehicle = {|
-  +type: ?string,
-  +uniqueNo: ?string,
-|};
-
-export type Segment = {|
-  +duration: ?number,
-  +id: ?string,
-  +transporter: ?Transporter,
-  +vehicle: ?Vehicle,
-  +arrival: ?RouteStop,
-  +departure: ?RouteStop,
-|};
-
-export type Sector = {|
-  +arrivalTime: ?Time,
-  +departureTime: ?Time,
-  +destination: ?Location,
-  +duration: ?number,
-  +origin: ?Location,
-  +segments: ?Array<Segment>,
-  +stopoverDuration: number | null,
-  +departure: RouteStop,
-  +arrival: RouteStop,
-|};
-
 export type Itinerary = {|
   +id: string,
-  +type: ?string,
-  +isValid: ?boolean,
-  +isChecked: ?boolean,
-  +bookingToken: ?string,
   +price: ?Price,
-  +origin: ?Location,
-  +destination: ?Location,
-  +startTime: ?Time,
-  +endTime: ?Time,
   +sectors: ?Array<Sector>,
+  +type: ?string,
+  +bookingToken: ?string,
+  +isChecked: ?boolean,
+  +isValid: ?boolean,
+  +departure: ?RouteStop,
+  +arrival: ?RouteStop,
 |};
 
 export type ApiRouteItem = {|

--- a/apps/graphql/src/apps/itinerary/dataloaders/Itineraries.js
+++ b/apps/graphql/src/apps/itinerary/dataloaders/Itineraries.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { head, last } from 'ramda';
 import stringify from 'json-stable-stringify';
 import qs from 'querystring';
 import * as DateFNS from 'date-fns';
@@ -7,13 +8,7 @@ import { OptimisticDataloader } from '@kiwicom/graphql-utils';
 import { UK_DATE_FORMAT } from '@kiwicom/margarita-config';
 
 import fetch from '../../../services/fetch/tequilaFetch';
-import {
-  mapLocation,
-  mapDate,
-  getItineraryType,
-  mapSectors,
-  unmaskID,
-} from '../helpers/Itineraries';
+import { getItineraryType, mapSectors, unmaskID } from '../helpers/Itineraries';
 import type {
   ItinerariesReturnSearchParameters,
   ItinerariesOneWaySearchParameters,
@@ -88,27 +83,24 @@ const sanitizeItineraries = (response: ApiResponseType): Itinerary[] => {
   const itineraries = response.data;
 
   return itineraries.map(itinerary => {
+    const type = getItineraryType(itinerary.routes);
+    const sectors = mapSectors(itinerary.route, itinerary.routes);
+
+    const departure = head(head(sectors ?? [])?.segments ?? [])?.departure;
+    const arrival =
+      type === 'return'
+        ? last(head(sectors ?? [])?.segments ?? [])?.arrival
+        : last(last(sectors ?? [])?.segments ?? [])?.arrival;
+
     return {
       id: itinerary.id,
-      type: getItineraryType(itinerary.routes),
+      type,
       bookingToken: itinerary.booking_token,
       isValid: false,
       isChecked: false,
-      startTime: mapDate(itinerary.local_departure, itinerary.utc_departure),
-      endTime: mapDate(itinerary.local_arrival, itinerary.utc_arrival),
-      destination: mapLocation(
-        itinerary.flyTo,
-        itinerary.cityTo,
-        itinerary.countryTo?.name,
-        itinerary.countryTo?.code,
-      ),
-      origin: mapLocation(
-        itinerary.flyFrom,
-        itinerary.cityFrom,
-        itinerary.countryFrom?.name,
-        itinerary.countryFrom?.code,
-      ),
-      sectors: mapSectors(itinerary.route, itinerary.routes),
+      departure,
+      arrival,
+      sectors,
       price: {
         currency: response.currency,
         amount: itinerary.price,

--- a/apps/graphql/src/apps/itinerary/dataloaders/Itinerary.js
+++ b/apps/graphql/src/apps/itinerary/dataloaders/Itinerary.js
@@ -52,10 +52,8 @@ const sanitizeItinerary = (response: ItineraryApiResponseType): Itinerary => {
     bookingToken: response.booking_token,
     isValid: !response.flights_invalid,
     isChecked: response.flights_checked,
-    startTime: null,
-    endTime: null,
-    origin: null,
-    destination: null,
+    departure: null,
+    arrival: null,
     sectors: null,
     price: {
       currency: 'EUR',

--- a/apps/graphql/src/apps/itinerary/helpers/__tests__/Itineraries.test.js
+++ b/apps/graphql/src/apps/itinerary/helpers/__tests__/Itineraries.test.js
@@ -1,10 +1,7 @@
 // @flow
 
 import {
-  mapLocationArea,
-  mapDate,
   getItineraryType,
-  mapLocation,
   mapTransporter,
   mapSectors,
   mapVehicle,
@@ -17,50 +14,6 @@ import {
   twoWayRoutesMap,
 } from '../../__mocks__/itinerariesMock';
 
-describe('mapLocationArea', () => {
-  const name = 'Czech republic';
-  const code = 'CZ';
-  const slug = 'slug';
-  const flagURL = 'flag';
-  it('returns proper structure of the Location Area object', () => {
-    expect(mapLocationArea(code, code, name, slug, flagURL)).toMatchObject({
-      id: code,
-      locationId: code,
-      name,
-      code,
-      slug,
-      flagURL,
-    });
-  });
-  it('returns empty structure of the Location Area object', () => {
-    expect(mapLocationArea()).toMatchObject({
-      id: null,
-      locationId: null,
-      name: null,
-      code: null,
-      slug: null,
-      flagURL: null,
-    });
-  });
-});
-
-describe('mapDate', () => {
-  it('returns proper structure of the Date object', () => {
-    const local = '2019-05-13T15:30:00.000Z';
-    const utc = '2019-05-13T13:30:00.000Z';
-    expect(mapDate(local, utc)).toMatchObject({
-      local: local,
-      utc: utc,
-    });
-  });
-  it('returns empty structure of the Date object', () => {
-    expect(mapDate()).toMatchObject({
-      local: null,
-      utc: null,
-    });
-  });
-});
-
 describe('getItineraryType', () => {
   const routesForReturnFlight = [['OSL', 'PRG'], ['PRG', 'OSL']];
   const routesForOneWayFlight = [['OSL', 'PRG']];
@@ -72,35 +25,6 @@ describe('getItineraryType', () => {
   });
   it('returns null flight type', () => {
     expect(getItineraryType()).toBeNull();
-  });
-});
-
-describe('mapLocation', () => {
-  it('returns proper structure of the Location object', () => {
-    const locationId = 'PRG';
-    const name = 'Prague';
-    const countryName = 'Czech republic';
-    const countryCode = 'CZ';
-    expect(
-      mapLocation(locationId, name, countryName, countryCode),
-    ).toMatchObject({
-      locationId,
-      name,
-      country: {
-        name: countryName,
-        code: countryCode,
-      },
-    });
-  });
-  it('returns empty structure of the Location object', () => {
-    expect(mapLocation()).toMatchObject({
-      locationId: null,
-      name: null,
-      country: {
-        name: null,
-        code: null,
-      },
-    });
   });
 });
 

--- a/apps/graphql/src/apps/itinerary/types/outputs/Itinerary.js
+++ b/apps/graphql/src/apps/itinerary/types/outputs/Itinerary.js
@@ -9,17 +9,14 @@ import {
 import GlobalID from '@kiwicom/graphql-global-id';
 import * as DateFNS from 'date-fns';
 
-import type { Itinerary, Sector } from '../../Itinerary';
+import type { Sector } from '../../../common/CommonTypes';
+import type { Itinerary } from '../../Itinerary';
 import GraphQLPrice from '../../../common/types/outputs/Price';
 import GraphQLSector from '../../../common/types/outputs/Sector';
-import GraphQLLocation from '../../../location/types/outputs/Location';
-import GraphQLDateType from '../../../common/types/outputs/DateType';
+import GraphQLRouteStop from '../../../common/types/outputs/RouteStop';
 
 const itineraryResponseFields = {
-  destination: { type: GraphQLLocation },
-  endTime: { type: GraphQLDateType },
   id: GlobalID(({ id }) => id),
-  origin: { type: GraphQLLocation },
   price: { type: GraphQLPrice },
   sectors: {
     type: new GraphQLList(GraphQLSector),
@@ -33,7 +30,12 @@ const itineraryResponseFields = {
       }));
     },
   },
-  startTime: { type: GraphQLDateType },
+  arrival: {
+    type: GraphQLRouteStop,
+  },
+  departure: {
+    type: GraphQLRouteStop,
+  },
   type: { type: GraphQLString },
   bookingToken: { type: GraphQLString },
   isChecked: {
@@ -59,8 +61,8 @@ const getStopoverDuration = (
     return null;
   }
 
-  const currentSectorDeparture = sector.departureTime?.utc;
-  const previousSectorArrival = previousSector.arrivalTime?.utc;
+  const currentSectorDeparture = sector.departure?.time?.utc;
+  const previousSectorArrival = previousSector.arrival?.time?.utc;
 
   if (currentSectorDeparture == null || previousSectorArrival == null) {
     return null;

--- a/schema.graphql
+++ b/schema.graphql
@@ -196,6 +196,14 @@ interface FromToInterface {
   type: BookingType
 }
 
+type GeoIP {
+  """ISO country code"""
+  isoCountryCode: String
+
+  """Coordinates"""
+  coordinates: Coordinate
+}
+
 type HttpError {
   code: Int!
   message: String!
@@ -230,19 +238,16 @@ input ItinerariesReturnSearchInput {
 }
 
 type Itinerary {
-  destination: Location
-  endTime: DateType
-
   """
   The globally unique ID of an object. You can unmask this ID to get original
   value but please note that this unmasked ID is not globally unique anymore and
   therefore it cannot be used as a cache key.
   """
   id(opaque: Boolean = true): ID!
-  origin: Location
   price: Price
   sectors: [Sector]
-  startTime: DateType
+  arrival: RouteStop
+  departure: RouteStop
   type: String
   bookingToken: String
 
@@ -452,6 +457,11 @@ type RootQuery {
 
   """Check if itinerary is valid and bookable"""
   checkItinerary(input: ItineraryCheckInput!): Itinerary
+
+  """
+  Geography info by an IP address, if no input provided, it will use request client IP
+  """
+  geoIP(ip: String): GeoIP
 }
 
 """Departure or arrival for a segment or sector"""


### PR DESCRIPTION
Summary:
- Merged Itinerary `endTime + destination` & `startTime + origin` to `arrival` & `departure` RouteStop types to make schema more consistent with bookings.
- Moved duplicate Itinerary and Booking flow types to `common` folder.

Before
<img width="125" alt="Screenshot 2019-03-29 at 17 14 30" src="https://user-images.githubusercontent.com/2660330/55246833-61973a80-5246-11e9-838a-577aceb2bda9.png">

After
<img width="119" alt="Screenshot 2019-03-29 at 17 14 49" src="https://user-images.githubusercontent.com/2660330/55246831-61973a80-5246-11e9-9ec3-a212c935ecf5.png">