### PR TITLE
Remove buffer dependency

### DIFF
--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,6 @@
     "@kiwicom/test-utils": "^0.5.0",
     "apollo-server": "^2.2.6",
     "apollo-server-lambda": "^2.4.8",
-    "buffer": "^5.2.1",
     "chalk": "^2.4.2",
     "dataloader": "^1.4.0",
     "graphql": "^14.0.2",

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import * as Expo from 'expo';
-import { Buffer } from 'buffer'; // eslint-disable-line node/prefer-global/buffer
 import { Fonts } from '@kiwicom/universal-components';
 
 import SharedApp from './App';
@@ -15,8 +14,6 @@ type Props = {||};
 type State = {|
   fontsLoaded: boolean,
 |};
-
-global.Buffer = Buffer; // No global Buffer in react-native, and graphql-relay needs it
 
 class App extends React.Component<Props, State> {
   constructor(props: Props) {


### PR DESCRIPTION
This was needed when we used the in memory graphql fetch approach.
We now have the graphql deployed on a server, so we dont need this anymore