### PR TITLE
UniversalComponents: ImportantNotification can have custom right icon

### DIFF
--- a/packages/universal-components/src/Notification/ImportantNotification.js
+++ b/packages/universal-components/src/Notification/ImportantNotification.js
@@ -7,15 +7,17 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Icon } from '../Icon';
 import { Touchable } from '../Touchable';
 import { StyleSheet } from '../PlatformStyleSheet';
+import { Text } from '../Text';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 import type { NotificationStyleType } from '../types';
-import { Text } from '../Text';
+import type { IconNameType } from '../types/_generated-types';
 
 type Props = {|
   +style?: StylePropType,
   +notificationStyle: NotificationStyleType,
   +notificationTitle: React.Node | string,
   +notificationMessage: React.Node | string,
+  +rightIconName?: IconNameType,
   +onPress: () => void,
 |};
 
@@ -27,6 +29,7 @@ export default function ImportantNotification({
   notificationTitle,
   notificationMessage,
   notificationStyle,
+  rightIconName,
 }: Props) {
   let color;
   let iconColor;
@@ -66,6 +69,10 @@ export default function ImportantNotification({
       iconRight = 'chevron-right';
       iconSize = 'medium';
     }
+  }
+
+  if (rightIconName != null) {
+    iconRight = rightIconName;
   }
 
   return (

--- a/packages/universal-components/src/Notification/Notification.js
+++ b/packages/universal-components/src/Notification/Notification.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Animated } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
+import type { IconNameType } from '../types/_generated-types';
 import { getStatusBarHeight } from '../utils/StatusBarHeight';
 import { StyleSheet } from '../PlatformStyleSheet';
 import InformativeNotification from './InformativeNotification';
@@ -32,6 +33,7 @@ type State = {|
   notificationStyle: NotificationStyleType,
   notificationTitle: React.Node | string,
   notificationMessage: React.Node | string,
+  rightIconName?: IconNameType,
 |};
 
 const ANIMATION_DURATION = 250;
@@ -50,6 +52,7 @@ export default class Notification extends React.Component<Props, State> {
     notificationStyle: 'error',
     notificationTitle: '',
     notificationMessage: '',
+    rightIconName: undefined,
   };
 
   componentWillUnmount() {
@@ -64,6 +67,7 @@ export default class Notification extends React.Component<Props, State> {
     notificationStyle: NotificationStyleType,
     title: React.Node | string,
     message: React.Node | string,
+    rightIconName?: IconNameType,
   ) {
     const { isOpen } = this.state;
     const { notificationType } = this.props;
@@ -76,6 +80,7 @@ export default class Notification extends React.Component<Props, State> {
           notificationStyle,
           notificationTitle: title,
           notificationMessage: message,
+          rightIconName: rightIconName,
         },
         () => this.showNotification(),
       );
@@ -110,6 +115,7 @@ export default class Notification extends React.Component<Props, State> {
     notificationStyle: NotificationStyleType,
     title: React.Node | string,
     message: React.Node | string,
+    rightIconName?: IconNameType,
   ) => {
     const { notificationType } = this.props;
     const { isOpen } = this.state;
@@ -120,7 +126,12 @@ export default class Notification extends React.Component<Props, State> {
     const timeToLiveOver = Math.abs(now - (this.lastCallTimestamp || 0));
 
     if (isImportant) {
-      this.internalToggleNotification(notificationStyle, title, message);
+      this.internalToggleNotification(
+        notificationStyle,
+        title,
+        message,
+        rightIconName,
+      );
     }
 
     if (
@@ -201,6 +212,7 @@ export default class Notification extends React.Component<Props, State> {
       notificationStyle,
       notificationMessage,
       notificationTitle,
+      rightIconName,
       isOpen,
     } = this.state;
 
@@ -270,6 +282,7 @@ export default class Notification extends React.Component<Props, State> {
             notificationStyle={notificationStyle}
             notificationTitle={notificationTitle}
             notificationMessage={notificationMessage}
+            rightIconName={rightIconName}
             onPress={this.dismissNotification}
           />
         )}

--- a/packages/universal-components/src/Notification/Notification.stories.js
+++ b/packages/universal-components/src/Notification/Notification.stories.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 
+import icons from '../Icon/icons.json';
 import NotificationExample from './NotificationExample';
 
 storiesOf('Notification', module)
@@ -22,6 +23,11 @@ storiesOf('Notification', module)
     );
     const message = text('Message', 'Error message');
     const title = text('Title', 'Error');
+    const rightIconName = select(
+      'Right Icon',
+      ['undefined', ...Object.keys(icons)],
+      'chevron-right',
+    );
 
     return (
       <NotificationExample
@@ -29,6 +35,7 @@ storiesOf('Notification', module)
         notificationStyle={notificationStyle}
         title={title}
         message={message}
+        rightIconName={rightIconName}
       />
     );
   });

--- a/packages/universal-components/src/Notification/NotificationExample.js
+++ b/packages/universal-components/src/Notification/NotificationExample.js
@@ -6,6 +6,7 @@ import { View } from 'react-native';
 import Notification from './Notification';
 import { Button } from '../Button';
 import { StyleSheet } from '../PlatformStyleSheet';
+import type { IconNameType } from '../types/_generated-types';
 import type { NotificationType } from '../types';
 
 type Props = {|
@@ -13,6 +14,7 @@ type Props = {|
   +notificationType: NotificationType,
   +title: React.Node | string,
   +message: React.Node | string,
+  +rightIconName?: IconNameType,
   +onDismiss?: () => void,
 |};
 export default class NotificationExample extends React.Component<Props> {
@@ -21,9 +23,14 @@ export default class NotificationExample extends React.Component<Props> {
   }
 
   renderNotification = () => {
-    const { notificationStyle, title, message } = this.props;
+    const { notificationStyle, title, message, rightIconName } = this.props;
     if (this.notification) {
-      this.notification.toggleNotification(notificationStyle, title, message);
+      this.notification.toggleNotification(
+        notificationStyle,
+        title,
+        message,
+        rightIconName,
+      );
     }
   };
 


### PR DESCRIPTION
Context: I need the right icon of the Notification component to be a `close` icon, and not `chevron-right`.

Note: I will create an issue for this component; it should be refactored to allow the consumer to display whatever they need inside this notification. It is not flexible enough right now in my opinion.