### PR TITLE
Fix: Button loader visibility

### DIFF
--- a/packages/universal-components/src/Button/ButtonContent.js
+++ b/packages/universal-components/src/Button/ButtonContent.js
@@ -1,0 +1,92 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import { Icon } from '../Icon';
+import { StyleSheet } from '../PlatformStyleSheet';
+import ButtonTitle from './ButtonTitle';
+import type { ButtonType, ButtonSize } from './ButtonTypes';
+import { textColor } from './styles';
+import type { IconSize } from '../Icon/IconTypes';
+
+type Props = {|
+  +type?: ButtonType,
+  +children?: React.Node,
+  +leftIcon?: React.Element<typeof Icon> | null,
+  +rightIcon?: React.Element<typeof Icon> | null,
+  +sublabel?: React.Node,
+  +label?: React.Node,
+  +size?: ButtonSize,
+|};
+
+const styleIcon = (
+  icon: ?React.Element<typeof Icon>,
+  type: ButtonType,
+  size: IconSize,
+): React.Element<typeof Icon> | null => {
+  return icon
+    ? React.cloneElement(icon, {
+        color: textColor[type],
+        size: size,
+      })
+    : null;
+};
+
+export default function ButtonContent({
+  type = 'primary',
+  children,
+  leftIcon: originalLeftIcon,
+  rightIcon: originalRightIcon,
+  sublabel,
+  label,
+  size,
+}: Props) {
+  const iconSize = size === 'normal' || size === 'large' ? 'medium' : 'small';
+  const leftIcon = styleIcon(originalLeftIcon, type, iconSize);
+  const rightIcon = styleIcon(originalRightIcon, type, iconSize);
+
+  const leftSpace = size === 'large' ? styles.leftSpaceLarge : styles.leftSpace;
+  const rightSpace =
+    size === 'large' ? styles.rightSpaceLarge : styles.rightSpace;
+
+  return (
+    <>
+      <View style={styles.row}>
+        {leftIcon != null && <View style={rightSpace}>{leftIcon}</View>}
+        {children ||
+          (label != null && (
+            <ButtonTitle text={label} type={type} size={size} />
+          ))}
+      </View>
+      <View style={styles.row}>
+        {sublabel != null && (
+          <View style={styles.row}>
+            <ButtonTitle text={sublabel} type={type} variant="sublabel" />
+          </View>
+        )}
+        {rightIcon != null && <View style={leftSpace}>{rightIcon}</View>}
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  leftSpace: {
+    marginStart: parseInt(defaultTokens.marginButtonIconNormal, 10),
+  },
+  leftSpaceLarge: {
+    marginStart: parseInt(defaultTokens.marginButtonIconLarge, 10),
+  },
+  rightSpace: {
+    marginEnd: parseInt(defaultTokens.marginButtonIconNormal, 10),
+  },
+  rightSpaceLarge: {
+    marginEnd: parseInt(defaultTokens.marginButtonIconLarge, 10),
+  },
+});

--- a/packages/universal-components/src/Button/ButtonInner.js
+++ b/packages/universal-components/src/Button/ButtonInner.js
@@ -6,12 +6,12 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Icon } from '../Icon';
 import { StyleSheet } from '../PlatformStyleSheet';
-import ButtonTitle from './ButtonTitle';
 import type { ButtonType, ButtonSize } from './ButtonTypes';
-import { textColor, wrapperColor } from './styles';
+import { wrapperColor } from './styles';
 import { size as buttonSizeStyle } from './styles/shared';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 import { Loader } from '../Loader';
+import ButtonContent from './ButtonContent';
 
 type Props = {|
   +children?: React.Node,
@@ -33,8 +33,8 @@ export default function ButtonInner({
   type = 'primary',
   testID: testIDProps,
   children,
-  leftIcon: originalLeftIcon,
-  rightIcon: originalRightIcon,
+  leftIcon,
+  rightIcon,
   sublabel,
   label,
   circled,
@@ -42,19 +42,6 @@ export default function ButtonInner({
   style,
   isLoading,
 }: Props) {
-  const iconSize = size === 'normal' || size === 'large' ? 'medium' : 'small';
-  const leftIcon = originalLeftIcon
-    ? React.cloneElement(originalLeftIcon, {
-        color: textColor[type],
-        size: iconSize,
-      })
-    : originalLeftIcon;
-  const rightIcon = originalRightIcon
-    ? React.cloneElement(originalRightIcon, {
-        color: textColor[type],
-        size: iconSize,
-      })
-    : originalRightIcon;
   let justifyContent = layout.default;
   if (leftIcon != null) {
     justifyContent = layout.flexStart;
@@ -68,20 +55,17 @@ export default function ButtonInner({
     testID = `ButtonInner${testIDProps}`;
   }
 
-  const leftSpace = size === 'large' ? layout.leftSpaceLarge : layout.leftSpace;
-  const rightSpace =
-    size === 'large' ? layout.rightSpaceLarge : layout.rightSpace;
   return (
     <View
       style={[
-        styleSheet.buttonWrapper,
-        disabled && styleSheet.disabled,
+        styles.buttonWrapper,
+        disabled && styles.disabled,
         typeTheme(type).wrapper,
         justifyContent,
-        circled && styleSheet.buttonCircled,
+        circled && styles.buttonCircled,
         sizeTheme(size, leftIcon != null, rightIcon != null).buttonSizeWrapper,
         style,
-        isLoading && styleSheet.loadingState,
+        isLoading && styles.loadingState,
       ]}
       testID={testID}
     >
@@ -92,26 +76,18 @@ export default function ButtonInner({
             ? defaultTokens.paletteProductNormal
             : defaultTokens.paletteWhite
         }
-        animating={isLoading}
+        isVisible={isLoading}
       />
-      {isLoading || (
-        <>
-          <View style={layout.row}>
-            {leftIcon != null && <View style={rightSpace}>{leftIcon}</View>}
-            {children ||
-              (label != null && (
-                <ButtonTitle text={label} type={type} size={size} />
-              ))}
-          </View>
-          <View style={layout.row}>
-            {sublabel != null && (
-              <View style={layout.row}>
-                <ButtonTitle text={sublabel} type={type} variant="sublabel" />
-              </View>
-            )}
-            {rightIcon != null && <View style={leftSpace}>{rightIcon}</View>}
-          </View>
-        </>
+      {!isLoading && (
+        <ButtonContent
+          type={type}
+          children={children}
+          leftIcon={leftIcon}
+          rightIcon={rightIcon}
+          sublabel={sublabel}
+          label={label}
+          size={size}
+        />
       )}
     </View>
   );
@@ -133,25 +109,9 @@ const layout = StyleSheet.create({
       justifyContent: 'center',
     },
   },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  leftSpace: {
-    marginStart: parseInt(defaultTokens.marginButtonIconNormal, 10),
-  },
-  leftSpaceLarge: {
-    marginStart: parseInt(defaultTokens.marginButtonIconLarge, 10),
-  },
-  rightSpace: {
-    marginEnd: parseInt(defaultTokens.marginButtonIconNormal, 10),
-  },
-  rightSpaceLarge: {
-    marginEnd: parseInt(defaultTokens.marginButtonIconLarge, 10),
-  },
 });
 
-const styleSheet = StyleSheet.create({
+const styles = StyleSheet.create({
   buttonWrapper: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/packages/universal-components/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/universal-components/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`Button - native should match snapshot diff 1`] = `
       }
     >
       <View
-@@ -33,22 +33,22 @@
+@@ -33,42 +33,136 @@
               \\"justifyContent\\": \\"center\\",
               \\"paddingVertical\\": 11,
             },
@@ -45,8 +45,6 @@ exports[`Button - native should match snapshot diff 1`] = `
           ]
         }
       >
-        <ActivityIndicator
-@@ -60,21 +60,115 @@
         <View
           style={
             Object {
@@ -170,27 +168,16 @@ exports[`Button - native should match snapshot difference with loading state 1`]
 - First value
 + Second value
 
-@@ -45,130 +45,21 @@
+@@ -45,124 +45,21 @@
               \\"height\\": 44,
               \\"paddingEnd\\": 12,
               \\"paddingStart\\": 12,
             },
             undefined,
 -           false,
-+           Object {
-+             \\"flexDirection\\": \\"column\\",
-+             \\"opacity\\": 0.5,
-+           },
-          ]
-        }
-      >
-        <ActivityIndicator
--         animating={false}
-+         animating={true}
-          color=\\"#fff\\"
-          hidesWhenStopped={true}
-          size=\\"small\\"
-        />
+-         ]
+-       }
+-     >
 -       <View
 -         style={
 -           Object {
@@ -201,7 +188,7 @@ exports[`Button - native should match snapshot difference with loading state 1`]
 -       >
 -         <View
 -           style={
--             Object {
+            Object {
 -               \\"marginEnd\\": 8,
 -             }
 -           }
@@ -294,15 +281,23 @@ exports[`Button - native should match snapshot difference with loading state 1`]
 -                 },
 -                 Object {
 -                   \\"color\\": \\"#0176D2\\",
--                 },
++             \\"flexDirection\\": \\"column\\",
++             \\"opacity\\": 0.5,
+            },
 -                 undefined,
--               ]
--             }
--           >
+          ]
+        }
+      >
 -             
 -           </Text>
 -         </View>
 -       </View>
++       <ActivityIndicator
++         animating={true}
++         color=\\"#fff\\"
++         hidesWhenStopped={true}
++         size=\\"small\\"
++       />
       </View>
     </View>
   </View>"
@@ -417,8 +412,8 @@ exports[`Button - web should match snapshot diff 1`] = `
         ]
       }
     >
-      <ActivityIndicator
-@@ -55,17 +53,76 @@
+      <View
+@@ -49,17 +47,76 @@
             \\"alignItems\\": \\"center\\",
             \\"flexDirection\\": \\"row\\",
           }
@@ -521,30 +516,19 @@ exports[`Button - web should match snapshot difference with loading state 1`] = 
       }
     }
   >
-@@ -35,94 +35,20 @@
+@@ -35,88 +35,20 @@
             \\"height\\": 44,
             \\"paddingEnd\\": 12,
             \\"paddingStart\\": 12,
           },
           undefined,
 -         false,
-+         Object {
-+           \\"flexDirection\\": \\"column\\",
-+           \\"opacity\\": 0.5,
-+         },
-        ]
-      }
-    >
-      <ActivityIndicator
--       animating={false}
-+       animating={true}
-        color=\\"#fff\\"
-        hidesWhenStopped={true}
-        size=\\"small\\"
-      />
+-       ]
+-     }
+-   >
 -     <View
 -       style={
--         Object {
+          Object {
 -           \\"alignItems\\": \\"center\\",
 -           \\"flexDirection\\": \\"row\\",
 -         }
@@ -562,7 +546,9 @@ exports[`Button - web should match snapshot difference with loading state 1`] = 
 -             Array [
 -               Object {
 -                 \\"fontFamily\\": \\"orbit-icons\\",
--               },
++           \\"flexDirection\\": \\"column\\",
++           \\"opacity\\": 0.5,
+          },
 -               Object {
 -                 \\"fontSize\\": 24,
 -                 \\"height\\": 24,
@@ -573,9 +559,9 @@ exports[`Button - web should match snapshot difference with loading state 1`] = 
 -                 \\"color\\": \\"#0176D2\\",
 -               },
 -               undefined,
--             ]
--           }
--         >
+        ]
+      }
+    >
 -           f
 -         </Text>
 -       </View>
@@ -619,6 +605,12 @@ exports[`Button - web should match snapshot difference with loading state 1`] = 
 -         </Text>
 -       </View>
 -     </View>
++     <ActivityIndicator
++       animating={true}
++       color=\\"#fff\\"
++       hidesWhenStopped={true}
++       size=\\"small\\"
++     />
     </View>
   </a>"
 `;

--- a/packages/universal-components/src/Icon/IconTypes.js
+++ b/packages/universal-components/src/Icon/IconTypes.js
@@ -3,11 +3,11 @@
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 import type { IconNameType } from '../types/_generated-types';
 
-type Size = 'small' | 'medium' | 'large';
+export type IconSize = 'small' | 'medium' | 'large';
 
 export type Props = {|
   +name?: IconNameType,
-  size?: Size,
+  size?: IconSize,
   color?: string,
   style?: StylePropType,
 |};

--- a/packages/universal-components/src/Loader/Loader.js
+++ b/packages/universal-components/src/Loader/Loader.js
@@ -7,13 +7,15 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 type Props = {|
   +size?: 'large' | 'small',
   +color?: string,
-  +animating?: boolean,
+  +isVisible?: boolean,
 |};
 
 export default function Loader({
   size = 'small',
   color = defaultTokens.paletteProductNormal,
-  animating = true,
+  isVisible = true,
 }: Props) {
-  return <ActivityIndicator size={size} color={color} animating={animating} />;
+  return isVisible ? (
+    <ActivityIndicator size={size} color={color} animating={isVisible} />
+  ) : null;
 }


### PR DESCRIPTION
Summary: Button loader is present in layout even if it's hidden.

<img width="111" alt="Screenshot 2019-04-08 at 12 42 36" src="https://user-images.githubusercontent.com/2660330/55719294-2cd17300-59fe-11e9-867e-db56498e28f3.png">
<img width="312" alt="Screenshot 2019-04-08 at 12 50 43" src="https://user-images.githubusercontent.com/2660330/55719309-335fea80-59fe-11e9-8de3-926224be5e6e.png">

Note: Maybe we can later refactor `ButtonInner` into two components to make insides slightly cleaner.
I've been also thinking about solving this issue directly inside `Loader` (simply returning `null` when `animating` is `false`). But at the and I think that handling it inside button is slightly better. There can be cases where hidden `Loader` inside layout can be required to prevent layout jumping while it is switched on/off. 