### PR TITLE
Fix: Updated example server path in .env

### DIFF
--- a/apps/graphql/.env-example
+++ b/apps/graphql/.env-example
@@ -1,3 +1,3 @@
 API_KEY=
-BASE_URL='https://kiwicom-test.apigee.net/'
+BASE_URL='https://kiwicom-prod.apigee.net/'
 NODE_ENV='development'


### PR DESCRIPTION
Summary: Recommended path in `.env` example should be to production server instead of test.