### PR TITLE
Feat: adding back netlify.toml and deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ coverage/
 # IDE
 .idea
 .vscode
+
+deploy

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "export": "next export",
-    "deploy": "next build && next export",
+    "deploy": "next build && next export -o ../../deploy",
     "analyze": "better-npm-run analyze"
   },
   "betterScripts": {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "yarn babel-node ./scripts/deploy.js"
+  publish = "deploy"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "server": "yarn workspace @kiwicom/margarita-graphql start",
     "web": "yarn workspace @kiwicom/margarita-web dev",
     "create-dotenv": "yarn babel-node ./scripts/create-dotenv.js",
-    "preweb:deploy": "yarn create-dotenv",
-    "web:deploy": "yarn workspace @kiwicom/margarita-web deploy",
     "web:analyze": "yarn workspace @kiwicom/margarita-web analyze",
     "docs": "yarn workspace @kiwicom/margarita-docs start",
     "docs:deploy": "yarn workspace @kiwicom/margarita-docs deploy",

--- a/packages/universal-components/package.json
+++ b/packages/universal-components/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "storybook": "start-storybook -p 9009 -c storybook -s ./fonts",
-    "storybook:build": "rimraf storybook-static; build-storybook -c storybook -s ./fonts",
+    "storybook:build": "build-storybook -c storybook -s ./fonts -o ../../deploy",
     "storybook:mobile": "yarn workspace @kiwicom/margarita-mobile-storybook start:universal-components",
     "prerelease": "node scripts/preparePackageJson.js",
     "release": "release-it --no-git",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+// @flow
+
+import { execSync } from 'child_process';
+
+execSync('rimraf deploy', { stdio: 'inherit' });
+
+const { SITE_ID } = process.env;
+
+/**
+ * This script allows to build the right site for Netlify, depending on an environment variable, SITE_ID, set per Netlify website.
+ * All built files should go into <ROOT_FOLDER>/deploy (cf. `publish` field in netlify.toml)
+ */
+
+switch (SITE_ID) {
+  case '@kiwicom/universal-components': {
+    execSync('yarn workspace @kiwicom/universal-components storybook:build', {
+      stdio: 'inherit',
+    });
+    break;
+  }
+  case '@kiwicom/margarita-web': {
+    execSync('yarn create-dotenv', { stdio: 'inherit' });
+    execSync('yarn workspace @kiwicom/margarita-web deploy', {
+      stdio: 'inherit',
+    });
+    break;
+  }
+  default: {
+    console.log('No SITE_ID environment variable was set; exiting.');
+  }
+}


### PR DESCRIPTION
Summary: This is to better version control the build commands for Netlify, instead of relying on their UI, to which I only have access. This should be merged after https://github.com/kiwicom/margarita/pull/656.
    It adds a deploy script that, based on an environment variable SITE_ID (that has to be set on Netlify's UI, sadly), will deploy the right site. This is a current limitation of `netlify.toml` as it does not support deploying multiple sites from one repository out of the box. (see https://github.com/netlify/netlify-cms/issues/1325 for more information)