### PR TITLE
Fix: Modal background opacity is not covering entire screen.

### DIFF
--- a/packages/universal-components/src/Modal/Modal.web.js
+++ b/packages/universal-components/src/Modal/Modal.web.js
@@ -77,8 +77,10 @@ const styles = StyleSheet.create({
     zIndex: parseInt(defaultTokens.zIndexModal, 10),
   },
   backdrop: {
-    position: 'absolute',
     height: '100%',
     width: '100%',
+    web: {
+      position: 'fixed',
+    },
   },
 });


### PR DESCRIPTION
Add position `fixed` on web for the backdrop of the Modal to fix this issue.
Closes #665 