### PR TITLE
Fix scrollbar interference in RangeDatePicker on web

### DIFF
--- a/packages/universal-components/src/RangeDatePicker/RangeDatePickerContent.js
+++ b/packages/universal-components/src/RangeDatePicker/RangeDatePickerContent.js
@@ -59,12 +59,15 @@ export default class RangeDatePickerContent extends React.Component<
             renderItem={this.renderMonthItem}
             extraData={this.props.selectedDates}
             initialNumToRender={2}
+            style={styles.flatList}
           />
         )}
       </View>
     );
   }
 }
+
+const scrollBarWidth = 17;
 
 const styles = StyleSheet.create({
   container: {
@@ -75,5 +78,8 @@ const styles = StyleSheet.create({
   },
   monthsContainer: {
     margin: parseFloat(defaultTokens.spaceXSmall),
+  },
+  flatList: {
+    web: { paddingEnd: scrollBarWidth },
   },
 });


### PR DESCRIPTION
Before: 
<img width="410" alt="56032040-5ac9f680-5d21-11e9-8bd1-e1fe00873732" src="https://user-images.githubusercontent.com/858321/56266643-03df6b00-60ed-11e9-8864-dde2ec2f4f25.png">

after:
<img width="282" alt="Screenshot 2019-04-17 at 08 36 42" src="https://user-images.githubusercontent.com/858321/56266608-ea3e2380-60ec-11e9-8e44-eaa49b92a5be.png">

(Closes #660 )