### PR TITLE
Feat: Added sector details to ResultDetail

### DIFF
--- a/apps/core/components/sectorDetails/ItinerarySectorDetails.js
+++ b/apps/core/components/sectorDetails/ItinerarySectorDetails.js
@@ -1,0 +1,48 @@
+// @flow
+
+import * as React from 'react';
+import { Card, StyleSheet } from '@kiwicom/universal-components';
+import { createFragmentContainer, graphql } from '@kiwicom/margarita-relay';
+import {
+  ItineraryTypeRenderer,
+  SectorDetailsWrapper,
+} from '@kiwicom/margarita-components';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import ItineraryOneWay from '../ItineraryCard/itineraryDetail/ItineraryOneWay';
+import ItineraryReturn from '../ItineraryCard/itineraryDetail/ItineraryReturn';
+import type { ItinerarySectorDetails_itinerary as ItineraryType } from './__generated__/ItinerarySectorDetails_itinerary.graphql';
+
+type Props = {|
+  +itinerary: ?ItineraryType,
+|};
+
+function ItinerarySectorDetails(props: Props) {
+  return (
+    <Card style={styles.container}>
+      <SectorDetailsWrapper>
+        <ItineraryTypeRenderer
+          typename={props.itinerary?.__typename}
+          oneWayComponent={<ItineraryOneWay itinerary={props.itinerary} />}
+          returnComponent={<ItineraryReturn itinerary={props.itinerary} />}
+        />
+      </SectorDetailsWrapper>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: parseFloat(defaultTokens.spaceSmall),
+  },
+});
+
+export default createFragmentContainer(ItinerarySectorDetails, {
+  itinerary: graphql`
+    fragment ItinerarySectorDetails_itinerary on ItineraryInterface {
+      __typename
+      ...ItineraryOneWay_itinerary
+      ...ItineraryReturn_itinerary
+    }
+  `,
+});

--- a/apps/core/components/sectorDetails/__generated__/ItinerarySectorDetails_itinerary.graphql.js
+++ b/apps/core/components/sectorDetails/__generated__/ItinerarySectorDetails_itinerary.graphql.js
@@ -1,0 +1,51 @@
+/**
+ * @flow
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment } from 'relay-runtime';
+type ItineraryOneWay_itinerary$ref = any;
+type ItineraryReturn_itinerary$ref = any;
+import type { FragmentReference } from "relay-runtime";
+declare export opaque type ItinerarySectorDetails_itinerary$ref: FragmentReference;
+export type ItinerarySectorDetails_itinerary = {|
+  +__typename: string,
+  +$fragmentRefs: ItineraryOneWay_itinerary$ref & ItineraryReturn_itinerary$ref,
+  +$refType: ItinerarySectorDetails_itinerary$ref,
+|};
+*/
+
+
+const node/*: ReaderFragment*/ = {
+  "kind": "Fragment",
+  "name": "ItinerarySectorDetails_itinerary",
+  "type": "ItineraryInterface",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__typename",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ItineraryOneWay_itinerary",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ItineraryReturn_itinerary",
+      "args": null
+    }
+  ]
+};
+// prettier-ignore
+(node/*: any*/).hash = 'd77fce9ed01a7843e9a57f92cd22fb55';
+module.exports = node;

--- a/apps/core/scenes/bookingDetail/sectorDetails/segments/SegmentContainer.js
+++ b/apps/core/scenes/bookingDetail/sectorDetails/segments/SegmentContainer.js
@@ -1,11 +1,12 @@
 // @flow
 
 import * as React from 'react';
-import { Touchable, Icon, StyleSheet } from '@kiwicom/universal-components';
-import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { Animated, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
-import { BookingTypeRenderer } from '@kiwicom/margarita-components';
+import {
+  BookingTypeRenderer,
+  SectorDetailsWrapper,
+} from '@kiwicom/margarita-components';
 
 import SegmentMap from './SegmentMap';
 import type { SegmentContainer_data as BookingType } from './__generated__/SegmentContainer_data.graphql';
@@ -17,90 +18,19 @@ type Props = {|
   +data: ?BookingType,
 |};
 
-type State = {|
-  +expandSegments: boolean,
-  +isDisabled: boolean,
-|};
-
-export class SegmentContainer extends React.Component<Props, State> {
-  constructor() {
-    super();
-
-    this.state = {
-      expandSegments: false,
-      isDisabled: false,
-    };
-
-    this.spinValue = new Animated.Value(0);
-  }
-
-  spinValue: Animated.Value;
-
-  toggleExpanded = () => {
-    this.setState({ isDisabled: true }, () => {
-      Animated.timing(this.spinValue, {
-        toValue: this.state.expandSegments ? 0 : 1,
-        duration: 250,
-        useNativeDriver: true,
-      }).start(() => {
-        this.setState(state => ({
-          expandSegments: !state.expandSegments,
-          isDisabled: false,
-        }));
-      });
-    });
-  };
-
-  render() {
-    const spin = this.spinValue.interpolate({
-      inputRange: [0, 1],
-      outputRange: ['0deg', '180deg'],
-    });
-
-    return (
-      <>
-        <Touchable
-          onPress={this.toggleExpanded}
-          disabled={this.state.isDisabled}
-        >
-          <Animated.View
-            style={[
-              styles.iconWrapper,
-              {
-                transform: [{ rotate: spin }, { perspective: 1000 }],
-              },
-            ]}
-          >
-            <Icon
-              name="chevron-down"
-              color={defaultTokens.paletteProductNormal}
-            />
-          </Animated.View>
-        </Touchable>
-        {this.state.expandSegments && (
-          <>
-            <BookingTypeRenderer
-              type={this.props.data?.__typename}
-              oneWayComponent={<SectorsListOneWay data={this.props.data} />}
-              returnComponent={<SectorsListReturn data={this.props.data} />}
-              multicityComponent={
-                <SectorsListMulticity data={this.props.data} />
-              }
-            />
-            {Platform.OS !== 'web' && <SegmentMap data={this.props.data} />}
-          </>
-        )}
-      </>
-    );
-  }
+export function SegmentContainer(props: Props) {
+  return (
+    <SectorDetailsWrapper>
+      <BookingTypeRenderer
+        type={props.data?.__typename}
+        oneWayComponent={<SectorsListOneWay data={props.data} />}
+        returnComponent={<SectorsListReturn data={props.data} />}
+        multicityComponent={<SectorsListMulticity data={props.data} />}
+      />
+      {Platform.OS !== 'web' && <SegmentMap data={props.data} />}
+    </SectorDetailsWrapper>
+  );
 }
-
-const styles = StyleSheet.create({
-  iconWrapper: {
-    flex: 1,
-    alignSelf: 'center',
-  },
-});
 
 export default createFragmentContainer(SegmentContainer, {
   data: graphql`

--- a/apps/core/scenes/bookingDetail/sectorDetails/segments/__tests__/__snapshots__/SegmentContainer.test.js.snap
+++ b/apps/core/scenes/bookingDetail/sectorDetails/segments/__tests__/__snapshots__/SegmentContainer.test.js.snap
@@ -2,41 +2,27 @@
 
 exports[`renders 1`] = `
 Object {
-  "output": <React.Fragment>
-    <Touchable
-      accessibilityComponentType="button"
-      accessibilityTraits="button"
-      borderlessRipple={false}
-      disabled={false}
-      onPress={[Function]}
-      rippleColor="rgba(0, 0, 0, 0.32)"
-    >
-      <AnimatedComponent
-        style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "flex": 1,
-            },
-            Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
-                },
-                Object {
-                  "perspective": 1000,
-                },
-              ],
-            },
-          ]
-        }
-      >
-        <Icon
-          color="#00a991"
-          name="chevron-down"
+  "output": <SectorDetailsWrapper>
+    <BookingTypeRenderer
+      multicityComponent={
+        <ForwardRef(Relay(SectorsListMulticity))
+          data={null}
         />
-      </AnimatedComponent>
-    </Touchable>
-  </React.Fragment>,
+      }
+      oneWayComponent={
+        <ForwardRef(Relay(SectorsListOneWay))
+          data={null}
+        />
+      }
+      returnComponent={
+        <ForwardRef(Relay(SectorsListReturn))
+          data={null}
+        />
+      }
+    />
+    <ForwardRef(Relay(SegmentMap))
+      data={null}
+    />
+  </SectorDetailsWrapper>,
 }
 `;

--- a/apps/core/scenes/resultDetail/ResultDetailInner.js
+++ b/apps/core/scenes/resultDetail/ResultDetailInner.js
@@ -82,7 +82,7 @@ class ResultDetailInner extends React.Component<Props> {
         />
       );
     }
-    return <ResultDetailContent data={this.props.data?.checkItinerary} />;
+    return <ResultDetailContent itinerary={this.props.data?.checkItinerary} />;
   }
 }
 
@@ -95,7 +95,7 @@ export default createRefetchContainer(
         checkItinerary(input: $input) {
           isChecked
           isValid
-          ...ResultDetailContent_data
+          ...ResultDetailContent_itinerary
         }
       }
     `,

--- a/apps/core/scenes/resultDetail/__generated__/ResultDetailInnerQuery.graphql.js
+++ b/apps/core/scenes/resultDetail/__generated__/ResultDetailInnerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash ed571121d6df14ae970901b6e9e5c5ac
+ * @relayHash 84f1e099a8755287b448166b519314a2
  */
 
 /* eslint-disable */
@@ -45,16 +45,111 @@ fragment ResultDetailInner_data_2VV6jB on RootQuery {
     __typename
     isChecked
     isValid
-    ...ResultDetailContent_data
+    ...ResultDetailContent_itinerary
     id
   }
 }
 
-fragment ResultDetailContent_data on ItineraryInterface {
+fragment ResultDetailContent_itinerary on ItineraryInterface {
   isChecked
   price {
     currency
     amount
+  }
+  ...ItinerarySectorDetails_itinerary
+}
+
+fragment ItinerarySectorDetails_itinerary on ItineraryInterface {
+  __typename
+  ...ItineraryOneWay_itinerary
+  ...ItineraryReturn_itinerary
+}
+
+fragment ItineraryOneWay_itinerary on ItineraryOneWay {
+  sector {
+    ...SectorDetail_data
+  }
+}
+
+fragment ItineraryReturn_itinerary on ItineraryReturn {
+  inbound {
+    ...SectorDetail_data
+  }
+  outbound {
+    ...SectorDetail_data
+  }
+}
+
+fragment SectorDetail_data on Sector {
+  ...SectorStopoverDuration_data
+  ...SectorHeader_data
+  segments {
+    id
+    departure {
+      time {
+        local
+      }
+    }
+    arrival {
+      time {
+        local
+      }
+    }
+    ...Segment_data
+  }
+}
+
+fragment SectorStopoverDuration_data on Sector {
+  stopoverDuration
+  departure {
+    stop {
+      city {
+        name
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment SectorHeader_data on Sector {
+  duration
+  arrival {
+    stop {
+      city {
+        name
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment Segment_data on Segment {
+  duration
+  arrival {
+    ...SegmentStopInfo_data
+  }
+  departure {
+    time {
+      local
+    }
+    ...SegmentStopInfo_data
+  }
+  carrier {
+    name
+    code
+  }
+}
+
+fragment SegmentStopInfo_data on RouteStop {
+  time {
+    local
+  }
+  stop {
+    name
+    locationId
+    id
   }
 }
 */
@@ -66,6 +161,176 @@ var v0 = [
     "name": "input",
     "type": "ItineraryCheckInput!",
     "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "stop",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Location",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "city",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "LocationArea",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v1/*: any*/)
+        ]
+      },
+      (v1/*: any*/)
+    ]
+  }
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "duration",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "time",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "DateType",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "local",
+        "args": null,
+        "storageKey": null
+      }
+    ]
+  },
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "stop",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Location",
+    "plural": false,
+    "selections": [
+      (v2/*: any*/),
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "locationId",
+        "args": null,
+        "storageKey": null
+      },
+      (v1/*: any*/)
+    ]
+  }
+],
+v6 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "stopoverDuration",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "departure",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "RouteStop",
+    "plural": false,
+    "selections": (v3/*: any*/)
+  },
+  (v4/*: any*/),
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "arrival",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "RouteStop",
+    "plural": false,
+    "selections": (v3/*: any*/)
+  },
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "segments",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Segment",
+    "plural": true,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "departure",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "RouteStop",
+        "plural": false,
+        "selections": (v5/*: any*/)
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "arrival",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "RouteStop",
+        "plural": false,
+        "selections": (v5/*: any*/)
+      },
+      (v4/*: any*/),
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "carrier",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Carrier",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "code",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
   }
 ];
 return {
@@ -115,13 +380,6 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "__typename",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "isChecked",
             "args": null,
             "storageKey": null
@@ -161,9 +419,52 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "id",
+            "name": "__typename",
             "args": null,
             "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "type": "ItineraryOneWay",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sector",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sector",
+                "plural": false,
+                "selections": (v6/*: any*/)
+              }
+            ]
+          },
+          {
+            "kind": "InlineFragment",
+            "type": "ItineraryReturn",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "inbound",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sector",
+                "plural": false,
+                "selections": (v6/*: any*/)
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "outbound",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sector",
+                "plural": false,
+                "selections": (v6/*: any*/)
+              }
+            ]
           }
         ]
       }
@@ -173,7 +474,7 @@ return {
     "operationKind": "query",
     "name": "ResultDetailInnerQuery",
     "id": null,
-    "text": "query ResultDetailInnerQuery(\n  $input: ItineraryCheckInput!\n) {\n  ...ResultDetailInner_data_2VV6jB\n}\n\nfragment ResultDetailInner_data_2VV6jB on RootQuery {\n  checkItinerary(input: $input) {\n    __typename\n    isChecked\n    isValid\n    ...ResultDetailContent_data\n    id\n  }\n}\n\nfragment ResultDetailContent_data on ItineraryInterface {\n  isChecked\n  price {\n    currency\n    amount\n  }\n}\n",
+    "text": "query ResultDetailInnerQuery(\n  $input: ItineraryCheckInput!\n) {\n  ...ResultDetailInner_data_2VV6jB\n}\n\nfragment ResultDetailInner_data_2VV6jB on RootQuery {\n  checkItinerary(input: $input) {\n    __typename\n    isChecked\n    isValid\n    ...ResultDetailContent_itinerary\n    id\n  }\n}\n\nfragment ResultDetailContent_itinerary on ItineraryInterface {\n  isChecked\n  price {\n    currency\n    amount\n  }\n  ...ItinerarySectorDetails_itinerary\n}\n\nfragment ItinerarySectorDetails_itinerary on ItineraryInterface {\n  __typename\n  ...ItineraryOneWay_itinerary\n  ...ItineraryReturn_itinerary\n}\n\nfragment ItineraryOneWay_itinerary on ItineraryOneWay {\n  sector {\n    ...SectorDetail_data\n  }\n}\n\nfragment ItineraryReturn_itinerary on ItineraryReturn {\n  inbound {\n    ...SectorDetail_data\n  }\n  outbound {\n    ...SectorDetail_data\n  }\n}\n\nfragment SectorDetail_data on Sector {\n  ...SectorStopoverDuration_data\n  ...SectorHeader_data\n  segments {\n    id\n    departure {\n      time {\n        local\n      }\n    }\n    arrival {\n      time {\n        local\n      }\n    }\n    ...Segment_data\n  }\n}\n\nfragment SectorStopoverDuration_data on Sector {\n  stopoverDuration\n  departure {\n    stop {\n      city {\n        name\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment SectorHeader_data on Sector {\n  duration\n  arrival {\n    stop {\n      city {\n        name\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Segment_data on Segment {\n  duration\n  arrival {\n    ...SegmentStopInfo_data\n  }\n  departure {\n    time {\n      local\n    }\n    ...SegmentStopInfo_data\n  }\n  carrier {\n    name\n    code\n  }\n}\n\nfragment SegmentStopInfo_data on RouteStop {\n  time {\n    local\n  }\n  stop {\n    name\n    locationId\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/apps/core/scenes/resultDetail/__generated__/ResultDetailInner_data.graphql.js
+++ b/apps/core/scenes/resultDetail/__generated__/ResultDetailInner_data.graphql.js
@@ -8,14 +8,14 @@
 
 /*::
 import type { ReaderFragment } from 'relay-runtime';
-type ResultDetailContent_data$ref = any;
+type ResultDetailContent_itinerary$ref = any;
 import type { FragmentReference } from "relay-runtime";
 declare export opaque type ResultDetailInner_data$ref: FragmentReference;
 export type ResultDetailInner_data = {|
   +checkItinerary: ?{|
     +isChecked: ?boolean,
     +isValid: ?boolean,
-    +$fragmentRefs: ResultDetailContent_data$ref,
+    +$fragmentRefs: ResultDetailContent_itinerary$ref,
   |},
   +$refType: ResultDetailInner_data$ref,
 |};
@@ -68,7 +68,7 @@ const node/*: ReaderFragment*/ = {
         },
         {
           "kind": "FragmentSpread",
-          "name": "ResultDetailContent_data",
+          "name": "ResultDetailContent_itinerary",
           "args": null
         }
       ]
@@ -76,5 +76,5 @@ const node/*: ReaderFragment*/ = {
   ]
 };
 // prettier-ignore
-(node/*: any*/).hash = '7ef96791fb3e0c95284e40ec183ef080';
+(node/*: any*/).hash = '09baa11b372dd55aa4e221d466f266b8';
 module.exports = node;

--- a/apps/core/scenes/resultDetail/__generated__/ResultDetailQuery.graphql.js
+++ b/apps/core/scenes/resultDetail/__generated__/ResultDetailQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 36018d7751afa4529158a652a071ce4c
+ * @relayHash d1ed05bbcb2f11a712bb271cb76a57ce
  */
 
 /* eslint-disable */
@@ -45,16 +45,111 @@ fragment ResultDetailInner_data_2VV6jB on RootQuery {
     __typename
     isChecked
     isValid
-    ...ResultDetailContent_data
+    ...ResultDetailContent_itinerary
     id
   }
 }
 
-fragment ResultDetailContent_data on ItineraryInterface {
+fragment ResultDetailContent_itinerary on ItineraryInterface {
   isChecked
   price {
     currency
     amount
+  }
+  ...ItinerarySectorDetails_itinerary
+}
+
+fragment ItinerarySectorDetails_itinerary on ItineraryInterface {
+  __typename
+  ...ItineraryOneWay_itinerary
+  ...ItineraryReturn_itinerary
+}
+
+fragment ItineraryOneWay_itinerary on ItineraryOneWay {
+  sector {
+    ...SectorDetail_data
+  }
+}
+
+fragment ItineraryReturn_itinerary on ItineraryReturn {
+  inbound {
+    ...SectorDetail_data
+  }
+  outbound {
+    ...SectorDetail_data
+  }
+}
+
+fragment SectorDetail_data on Sector {
+  ...SectorStopoverDuration_data
+  ...SectorHeader_data
+  segments {
+    id
+    departure {
+      time {
+        local
+      }
+    }
+    arrival {
+      time {
+        local
+      }
+    }
+    ...Segment_data
+  }
+}
+
+fragment SectorStopoverDuration_data on Sector {
+  stopoverDuration
+  departure {
+    stop {
+      city {
+        name
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment SectorHeader_data on Sector {
+  duration
+  arrival {
+    stop {
+      city {
+        name
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment Segment_data on Segment {
+  duration
+  arrival {
+    ...SegmentStopInfo_data
+  }
+  departure {
+    time {
+      local
+    }
+    ...SegmentStopInfo_data
+  }
+  carrier {
+    name
+    code
+  }
+}
+
+fragment SegmentStopInfo_data on RouteStop {
+  time {
+    local
+  }
+  stop {
+    name
+    locationId
+    id
   }
 }
 */
@@ -66,6 +161,176 @@ var v0 = [
     "name": "input",
     "type": "ItineraryCheckInput!",
     "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "stop",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Location",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "city",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "LocationArea",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v1/*: any*/)
+        ]
+      },
+      (v1/*: any*/)
+    ]
+  }
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "duration",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "time",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "DateType",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "local",
+        "args": null,
+        "storageKey": null
+      }
+    ]
+  },
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "stop",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Location",
+    "plural": false,
+    "selections": [
+      (v2/*: any*/),
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "locationId",
+        "args": null,
+        "storageKey": null
+      },
+      (v1/*: any*/)
+    ]
+  }
+],
+v6 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "stopoverDuration",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "departure",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "RouteStop",
+    "plural": false,
+    "selections": (v3/*: any*/)
+  },
+  (v4/*: any*/),
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "arrival",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "RouteStop",
+    "plural": false,
+    "selections": (v3/*: any*/)
+  },
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "segments",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Segment",
+    "plural": true,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "departure",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "RouteStop",
+        "plural": false,
+        "selections": (v5/*: any*/)
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "arrival",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "RouteStop",
+        "plural": false,
+        "selections": (v5/*: any*/)
+      },
+      (v4/*: any*/),
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "carrier",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Carrier",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "code",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
   }
 ];
 return {
@@ -115,13 +380,6 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "__typename",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "isChecked",
             "args": null,
             "storageKey": null
@@ -161,9 +419,52 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "id",
+            "name": "__typename",
             "args": null,
             "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "type": "ItineraryOneWay",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sector",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sector",
+                "plural": false,
+                "selections": (v6/*: any*/)
+              }
+            ]
+          },
+          {
+            "kind": "InlineFragment",
+            "type": "ItineraryReturn",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "inbound",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sector",
+                "plural": false,
+                "selections": (v6/*: any*/)
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "outbound",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sector",
+                "plural": false,
+                "selections": (v6/*: any*/)
+              }
+            ]
           }
         ]
       }
@@ -173,7 +474,7 @@ return {
     "operationKind": "query",
     "name": "ResultDetailQuery",
     "id": null,
-    "text": "query ResultDetailQuery(\n  $input: ItineraryCheckInput!\n) {\n  ...ResultDetailInner_data_2VV6jB\n}\n\nfragment ResultDetailInner_data_2VV6jB on RootQuery {\n  checkItinerary(input: $input) {\n    __typename\n    isChecked\n    isValid\n    ...ResultDetailContent_data\n    id\n  }\n}\n\nfragment ResultDetailContent_data on ItineraryInterface {\n  isChecked\n  price {\n    currency\n    amount\n  }\n}\n",
+    "text": "query ResultDetailQuery(\n  $input: ItineraryCheckInput!\n) {\n  ...ResultDetailInner_data_2VV6jB\n}\n\nfragment ResultDetailInner_data_2VV6jB on RootQuery {\n  checkItinerary(input: $input) {\n    __typename\n    isChecked\n    isValid\n    ...ResultDetailContent_itinerary\n    id\n  }\n}\n\nfragment ResultDetailContent_itinerary on ItineraryInterface {\n  isChecked\n  price {\n    currency\n    amount\n  }\n  ...ItinerarySectorDetails_itinerary\n}\n\nfragment ItinerarySectorDetails_itinerary on ItineraryInterface {\n  __typename\n  ...ItineraryOneWay_itinerary\n  ...ItineraryReturn_itinerary\n}\n\nfragment ItineraryOneWay_itinerary on ItineraryOneWay {\n  sector {\n    ...SectorDetail_data\n  }\n}\n\nfragment ItineraryReturn_itinerary on ItineraryReturn {\n  inbound {\n    ...SectorDetail_data\n  }\n  outbound {\n    ...SectorDetail_data\n  }\n}\n\nfragment SectorDetail_data on Sector {\n  ...SectorStopoverDuration_data\n  ...SectorHeader_data\n  segments {\n    id\n    departure {\n      time {\n        local\n      }\n    }\n    arrival {\n      time {\n        local\n      }\n    }\n    ...Segment_data\n  }\n}\n\nfragment SectorStopoverDuration_data on Sector {\n  stopoverDuration\n  departure {\n    stop {\n      city {\n        name\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment SectorHeader_data on Sector {\n  duration\n  arrival {\n    stop {\n      city {\n        name\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Segment_data on Segment {\n  duration\n  arrival {\n    ...SegmentStopInfo_data\n  }\n  departure {\n    time {\n      local\n    }\n    ...SegmentStopInfo_data\n  }\n  carrier {\n    name\n    code\n  }\n}\n\nfragment SegmentStopInfo_data on RouteStop {\n  time {\n    local\n  }\n  stop {\n    name\n    locationId\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailContent.js
+++ b/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailContent.js
@@ -17,10 +17,11 @@ import { formatPrice } from '@kiwicom/margarita-localization';
 
 import { PriceSummary } from '../../../components/priceSummary';
 import ResultDetailPassenger from './ResultDetailPassenger';
-import type { ResultDetailContent_data as ResultDetailContentType } from './__generated__/ResultDetailContent_data.graphql';
+import type { ResultDetailContent_itinerary as ResultDetailContentType } from './__generated__/ResultDetailContent_itinerary.graphql';
+import ItinerarySectorDetails from '../../../components/sectorDetails/ItinerarySectorDetails';
 
 type Props = {|
-  +data: ?ResultDetailContentType,
+  +itinerary: ?ResultDetailContentType,
   +navigation: Navigation,
 |};
 
@@ -59,12 +60,13 @@ class ResultDetailContent extends React.Component<Props, State> {
 
   render() {
     const localizedPrice = formatPrice(
-      this.props.data?.price?.amount,
-      this.props.data?.price?.currency,
+      this.props.itinerary?.price?.amount,
+      this.props.itinerary?.price?.currency,
     );
     return (
       <>
         <ContentContainer>
+          <ItinerarySectorDetails itinerary={this.props.itinerary} />
           <ResultDetailPassenger />
           <ContactDetailsForm
             onChangeEmail={this.handleChangeEmail}
@@ -73,7 +75,7 @@ class ResultDetailContent extends React.Component<Props, State> {
           />
         </ContentContainer>
         <PriceSummary
-          isLoading={!this.props.data?.isChecked}
+          isLoading={!this.props.itinerary?.isChecked}
           onButtonPress={this.handleContinue}
           renderCollapseContent={
             <>
@@ -107,13 +109,14 @@ class ResultDetailContent extends React.Component<Props, State> {
 }
 
 export default createFragmentContainer(withNavigation(ResultDetailContent), {
-  data: graphql`
-    fragment ResultDetailContent_data on ItineraryInterface {
+  itinerary: graphql`
+    fragment ResultDetailContent_itinerary on ItineraryInterface {
       isChecked
       price {
         currency
         amount
       }
+      ...ItinerarySectorDetails_itinerary
     }
   `,
 });

--- a/apps/core/scenes/resultDetail/resultDetailContent/__generated__/ResultDetailContent_itinerary.graphql.js
+++ b/apps/core/scenes/resultDetail/resultDetailContent/__generated__/ResultDetailContent_itinerary.graphql.js
@@ -8,22 +8,24 @@
 
 /*::
 import type { ReaderFragment } from 'relay-runtime';
+type ItinerarySectorDetails_itinerary$ref = any;
 import type { FragmentReference } from "relay-runtime";
-declare export opaque type ResultDetailContent_data$ref: FragmentReference;
-export type ResultDetailContent_data = {|
+declare export opaque type ResultDetailContent_itinerary$ref: FragmentReference;
+export type ResultDetailContent_itinerary = {|
   +isChecked: ?boolean,
   +price: ?{|
     +currency: ?string,
     +amount: ?number,
   |},
-  +$refType: ResultDetailContent_data$ref,
+  +$fragmentRefs: ItinerarySectorDetails_itinerary$ref,
+  +$refType: ResultDetailContent_itinerary$ref,
 |};
 */
 
 
 const node/*: ReaderFragment*/ = {
   "kind": "Fragment",
-  "name": "ResultDetailContent_data",
+  "name": "ResultDetailContent_itinerary",
   "type": "ItineraryInterface",
   "metadata": null,
   "argumentDefinitions": [],
@@ -59,9 +61,14 @@ const node/*: ReaderFragment*/ = {
           "storageKey": null
         }
       ]
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ItinerarySectorDetails_itinerary",
+      "args": null
     }
   ]
 };
 // prettier-ignore
-(node/*: any*/).hash = '6e81bb8ef7f9193792695ace2fe5d4c5';
+(node/*: any*/).hash = '65f0a90761521f5fa595def55fcfc9eb';
 module.exports = node;

--- a/packages/components/index.js
+++ b/packages/components/index.js
@@ -75,3 +75,6 @@ export { SortTabs } from './src/sortTabs';
 export {
   default as ContentContainer,
 } from './src/contentContainer/ContentContainer';
+export {
+  default as SectorDetailsWrapper,
+} from './src/sectorDetailsWrapper/SectorDetailsWrapper';

--- a/packages/components/src/sectorDetailsWrapper/SectorDetailsWrapper.js
+++ b/packages/components/src/sectorDetailsWrapper/SectorDetailsWrapper.js
@@ -1,0 +1,86 @@
+// @flow
+
+import * as React from 'react';
+import { Touchable, Icon, StyleSheet } from '@kiwicom/universal-components';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+import { Animated } from 'react-native';
+
+type Props = {|
+  +children: React.Node,
+|};
+
+type State = {|
+  +isExpanded: boolean,
+  +isDisabled: boolean,
+|};
+
+export default class SectorDetailsWrapper extends React.Component<
+  Props,
+  State,
+> {
+  constructor() {
+    super();
+
+    this.state = {
+      isExpanded: false,
+      isDisabled: false,
+    };
+
+    this.spinValue = new Animated.Value(0);
+  }
+
+  spinValue: Animated.Value;
+
+  toggleExpanded = () => {
+    this.setState({ isDisabled: true }, () => {
+      Animated.timing(this.spinValue, {
+        toValue: this.state.isExpanded ? 0 : 1,
+        duration: 250,
+        useNativeDriver: true,
+      }).start(() => {
+        this.setState(state => ({
+          isExpanded: !state.isExpanded,
+          isDisabled: false,
+        }));
+      });
+    });
+  };
+
+  render() {
+    const spin = this.spinValue.interpolate({
+      inputRange: [0, 1],
+      outputRange: ['0deg', '180deg'],
+    });
+
+    return (
+      <>
+        <Touchable
+          onPress={this.toggleExpanded}
+          disabled={this.state.isDisabled}
+        >
+          <Animated.View
+            style={[
+              styles.iconWrapper,
+              {
+                transform: [{ rotate: spin }, { perspective: 1000 }],
+              },
+            ]}
+          >
+            <Icon
+              name="chevron-down"
+              color={defaultTokens.paletteProductNormal}
+            />
+          </Animated.View>
+        </Touchable>
+        {this.state.isExpanded && this.props.children}
+      </>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  iconWrapper: {
+    flex: 1,
+    alignSelf: 'center',
+  },
+});


### PR DESCRIPTION
Summary:
- Extracted `SectorDetailsWrapper` from MMB sector details to make it reusable for results.
- Added expandable sector details to result. According to designs.
https://www.figma.com/file/OUhBJ9rPaTbRljptC0lrRrUF/Multistep

![sector-details](https://user-images.githubusercontent.com/2660330/56281434-e28e7700-610c-11e9-952d-ecb59d6cb39b.gif)

Top part of the header will follow in different PR.

<img width="464" alt="Screenshot 2019-04-16 at 18 40 43" src="https://user-images.githubusercontent.com/2660330/56281447-eb7f4880-610c-11e9-9614-468da2133458.png">