### PR TITLE
Fix: Set Navbar background color

### DIFF
--- a/apps/web/components/Navbar.js
+++ b/apps/web/components/Navbar.js
@@ -51,6 +51,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     flexDirection: 'row',
+    backgroundColor: defaultTokens.paletteWhite,
   },
   image: {
     height: 50,

--- a/apps/web/components/__tests__/Navbar.test.js
+++ b/apps/web/components/__tests__/Navbar.test.js
@@ -12,6 +12,7 @@ it('renders', () => {
   style={
     Object {
       "alignItems": "center",
+      "backgroundColor": "#fff",
       "flexDirection": "row",
       "height": 50,
       "justifyContent": "space-between",


### PR DESCRIPTION
To prevent underlying elements to be visible.

Before
<img width="548" alt="Screenshot 2019-04-18 at 17 12 15" src="https://user-images.githubusercontent.com/2660330/56371756-0382c500-61fe-11e9-868b-8c0e2ec88e16.png">

After
<img width="556" alt="Screenshot 2019-04-18 at 17 11 55" src="https://user-images.githubusercontent.com/2660330/56371760-067db580-61fe-11e9-89ec-98eb4d8a0642.png">