### PR TITLE
Feat: Added HoldBagOptions to Itinerary

### DIFF
--- a/apps/graphql/src/apps/common/CommonTypes.js
+++ b/apps/graphql/src/apps/common/CommonTypes.js
@@ -42,3 +42,10 @@ export type Vehicle = {|
   +type: ?string,
   +uniqueNo: ?string,
 |};
+
+export type HoldBagOption = {|
+  +quantity: ?number,
+  +price: ?Price,
+  +dimensions: ?string,
+  +weight: ?string,
+|};

--- a/apps/graphql/src/apps/itinerary/Itinerary.js
+++ b/apps/graphql/src/apps/itinerary/Itinerary.js
@@ -2,14 +2,21 @@
 
 import { type TripTypes } from '@kiwicom/margarita-config';
 
-import type { RouteStop, Sector, Price } from '../common/CommonTypes';
+import type {
+  RouteStop,
+  Sector,
+  Price,
+  HoldBagOption,
+} from '../common/CommonTypes';
 
 type Order = 'ASC' | 'DESC';
 type Sort = 'price' | 'duration' | 'quality' | 'date' | 'popularity';
+
 type DateRange = {|
   start: Date,
   end?: Date,
 |};
+
 type Passengers = {|
   +adults?: number,
   +children?: number,
@@ -59,6 +66,14 @@ export type Itinerary = {|
   +isValid: ?boolean,
   +departure: ?RouteStop,
   +arrival: ?RouteStop,
+  +holdBagOptions: ?Array<HoldBagOption>,
+|};
+
+export type HoldBagProps = {|
+  +weight: ?number,
+  +width: ?number,
+  +height: ?number,
+  +length: ?number,
 |};
 
 export type ApiRouteItem = {|
@@ -81,9 +96,17 @@ export type ApiCountry = {|
   +name: string,
 |};
 
+export type ApiBagsPrice = { [string]: ?number };
+export type ApiBagsLimits = {|
+  hold_weight?: number,
+  hold_width?: number,
+  hold_height?: number,
+  hold_length?: number,
+|};
+
 // @TODO data should be with "?"
-export type ApiResponseType = {|
-  +currency: string,
+export type ItinerariesApiResponse = {|
+  +currency?: string,
   +data: $ReadOnlyArray<{|
     +id: string,
     +airlines: Array<string>,
@@ -101,15 +124,20 @@ export type ApiResponseType = {|
     +route: Array<ApiRouteItem>,
     +routes: Array<Array<string>>,
     +booking_token: string,
+    +bags_price?: ApiBagsPrice,
+    +baglimit?: ApiBagsLimits,
   |}>,
 |};
 
 export type ItineraryApiResponse = {|
+  +currency?: string,
   +flights_checked?: boolean,
   +flights_invalid?: boolean,
   +booking_token?: string,
   +total?: number,
   +flights?: Array<ItineraryApiSegment>,
+  +bags_price?: ApiBagsPrice,
+  +luggage?: $ReadOnlyArray<?number>,
 |};
 
 export type ItineraryApiSegment = {|

--- a/apps/graphql/src/apps/itinerary/dataloaders/Itinerary.js
+++ b/apps/graphql/src/apps/itinerary/dataloaders/Itinerary.js
@@ -13,11 +13,13 @@ import type {
 import {
   getItineraryDeparture,
   getItineraryArrival,
+  getHoldBagOptions,
 } from '../helpers/Itineraries';
 import {
   sanitizeSectors,
   getItineraryId,
   getItineraryType,
+  sanitizeHoldBagProps,
 } from '../helpers/Itinerary';
 
 export const parseParameters = (input: ItineraryCheckParameters) => {
@@ -54,10 +56,17 @@ const sanitizeItinerary = (response: ItineraryApiResponse): Itinerary => {
    * @TODO - `price.currency` - Tequila API currently always returns total price
    * in EUR, should be unified with search results where currency can be variable
    */
+  const currency = response.currency;
   const sectors = sanitizeSectors(response.flights);
   const type = getItineraryType(sectors);
   const departure = getItineraryDeparture(sectors);
   const arrival = getItineraryArrival(type, sectors);
+  const holdBagProps = sanitizeHoldBagProps(response.luggage);
+  const holdBagOptions = getHoldBagOptions(
+    response.bags_price,
+    currency,
+    holdBagProps,
+  );
 
   return {
     id: getItineraryId(response.flights),
@@ -68,8 +77,9 @@ const sanitizeItinerary = (response: ItineraryApiResponse): Itinerary => {
     departure,
     arrival,
     sectors,
+    holdBagOptions,
     price: {
-      currency: 'EUR',
+      currency,
       amount: response.total,
     },
   };

--- a/apps/graphql/src/apps/itinerary/helpers/Itinerary.js
+++ b/apps/graphql/src/apps/itinerary/helpers/Itinerary.js
@@ -4,7 +4,7 @@ import { head, last } from 'ramda';
 import { TRIP_TYPES, type TripTypes } from '@kiwicom/margarita-config';
 
 import { differenceInMinutes } from './Itineraries';
-import type { ItineraryApiSegment } from '../Itinerary';
+import type { ItineraryApiSegment, HoldBagProps } from '../Itinerary';
 import type {
   RouteStop,
   Sector,
@@ -122,4 +122,15 @@ export const getItineraryType = (sectors: ?Array<Sector>): ?TripTypes => {
     default:
       return null;
   }
+};
+
+export const sanitizeHoldBagProps = (
+  bagProps: ?$ReadOnlyArray<?number>,
+): HoldBagProps => {
+  return {
+    weight: bagProps?.[4],
+    width: bagProps?.[6],
+    height: bagProps?.[7],
+    length: bagProps?.[5],
+  };
 };

--- a/apps/graphql/src/apps/itinerary/queries/__tests__/__fixtures__/checkItinerary/CheckItinerary.graphql
+++ b/apps/graphql/src/apps/itinerary/queries/__tests__/__fixtures__/checkItinerary/CheckItinerary.graphql
@@ -34,6 +34,15 @@ fragment Sector on Sector {
       currency
       amount
     }
+    holdBagOptions {
+      quantity,
+      dimensions,
+      weight,
+      price {
+        currency
+        amount
+      },
+    }
     departure {
       ...RouteStopFragment
     }

--- a/apps/graphql/src/apps/itinerary/queries/__tests__/__fixtures__/itineraries/ItinerariesOneWay.graphql
+++ b/apps/graphql/src/apps/itinerary/queries/__tests__/__fixtures__/itineraries/ItinerariesOneWay.graphql
@@ -30,6 +30,15 @@ fragment RouteStopFragment on RouteStop {
     edges {
       node {
         id
+        holdBagOptions {
+          quantity,
+          dimensions,
+          weight,
+          price {
+            currency
+            amount
+          },
+        }
         ... on ItineraryOneWay {
           sector {
             duration

--- a/apps/graphql/src/apps/itinerary/queries/__tests__/__fixtures__/itineraries/ItinerariesReturn.graphql
+++ b/apps/graphql/src/apps/itinerary/queries/__tests__/__fixtures__/itineraries/ItinerariesReturn.graphql
@@ -53,6 +53,15 @@ fragment Sector on Sector {
     edges {
       node {
         id
+        holdBagOptions {
+          quantity,
+          dimensions,
+          weight,
+          price {
+            currency
+            amount
+          },
+        }
           ... on ItineraryReturn {
           inbound {
             ...Sector

--- a/apps/graphql/src/apps/itinerary/queries/__tests__/__snapshots__/CheckItineraryQueries.test.js.snap
+++ b/apps/graphql/src/apps/itinerary/queries/__tests__/__snapshots__/CheckItineraryQueries.test.js.snap
@@ -38,6 +38,15 @@ fragment Sector on Sector {
       currency
       amount
     }
+    holdBagOptions {
+      quantity,
+      dimensions,
+      weight,
+      price {
+        currency
+        amount
+      },
+    }
     departure {
       ...RouteStopFragment
     }
@@ -67,6 +76,17 @@ fragment Sector on Sector {
         "currency": "EUR",
         "amount": 692.88
       },
+      "holdBagOptions": [
+        {
+          "quantity": 1,
+          "dimensions": "27 x 52 x 78",
+          "weight": "23 kg",
+          "price": {
+            "currency": "EUR",
+            "amount": 117.6
+          }
+        }
+      ],
       "departure": {
         "time": {
           "utc": "2019-03-07T20:30:00.000Z",

--- a/apps/graphql/src/apps/itinerary/queries/__tests__/__snapshots__/ItinerariesQueries.test.js.snap
+++ b/apps/graphql/src/apps/itinerary/queries/__tests__/__snapshots__/ItinerariesQueries.test.js.snap
@@ -34,6 +34,15 @@ fragment RouteStopFragment on RouteStop {
     edges {
       node {
         id
+        holdBagOptions {
+          quantity,
+          dimensions,
+          weight,
+          price {
+            currency
+            amount
+          },
+        }
         ... on ItineraryOneWay {
           sector {
             duration
@@ -67,6 +76,7 @@ fragment RouteStopFragment on RouteStop {
         {
           "node": {
             "id": "SXRpbmVyYXJ5T25lV2F5OjM5OTEyMjc5NzgyMjAxMTlfMHwzOTE1MzYxNjAzMzExMTg1XzB8ODc3NjMwMTgzOTg2NDEyM18wfDEyMzQ1MzE2NjE2NTYxNjc4XzA=",
+            "holdBagOptions": [],
             "sector": {
               "duration": 3435,
               "stopoverDuration": null,
@@ -206,6 +216,15 @@ fragment Sector on Sector {
     edges {
       node {
         id
+        holdBagOptions {
+          quantity,
+          dimensions,
+          weight,
+          price {
+            currency
+            amount
+          },
+        }
           ... on ItineraryReturn {
           inbound {
             ...Sector
@@ -227,6 +246,17 @@ fragment Sector on Sector {
         {
           "node": {
             "id": "SXRpbmVyYXJ5UmV0dXJuOjg5MDM4NDUxNzc0NDY4MDRfMHwxOTkxMjE1NjA5MTk5OTM2Ml8wfDE5OTEyMTU2MDkxOTk5MzYyXzF8MTk5MTIxNTYwOTE5OTkzNjJfMnwxOTkxMjE1NjA5MTk5OTM2Ml8zfDQwNTA2MDIwNjQ0NTk4MTVfMA==",
+            "holdBagOptions": [
+              {
+                "quantity": 1,
+                "dimensions": null,
+                "weight": "20 kg",
+                "price": {
+                  "currency": "EUR",
+                  "amount": 160.19
+                }
+              }
+            ],
             "inbound": {
               "duration": 1866,
               "stopoverDuration": 44729,

--- a/apps/graphql/src/apps/itinerary/types/outputs/HoldBagOption.js
+++ b/apps/graphql/src/apps/itinerary/types/outputs/HoldBagOption.js
@@ -1,0 +1,15 @@
+// @flow
+
+import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql';
+
+import GraphQLPrice from '../../../common/types/outputs/Price';
+
+export default new GraphQLObjectType({
+  name: 'HoldBagOption',
+  fields: {
+    quantity: { type: GraphQLInt },
+    price: { type: GraphQLPrice },
+    dimensions: { type: GraphQLString },
+    weight: { type: GraphQLString },
+  },
+});

--- a/apps/graphql/src/apps/itinerary/types/outputs/ItineraryInterface.js
+++ b/apps/graphql/src/apps/itinerary/types/outputs/ItineraryInterface.js
@@ -1,10 +1,16 @@
 // @flow
 
-import { GraphQLInterfaceType, GraphQLString, GraphQLBoolean } from 'graphql';
+import {
+  GraphQLInterfaceType,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLList,
+} from 'graphql';
 import GlobalID from '@kiwicom/graphql-global-id';
 
 import GraphQLPrice from '../../../common/types/outputs/Price';
 import GraphQLRouteStop from '../../../common/types/outputs/RouteStop';
+import GraphQLHoldBagOption from './HoldBagOption';
 
 export const commonFields = {
   id: GlobalID(({ id }) => id),
@@ -24,6 +30,7 @@ export const commonFields = {
     type: GraphQLBoolean,
     description: 'Itinerary is valid (exists and is not sold-out or cancelled)',
   },
+  holdBagOptions: { type: new GraphQLList(GraphQLHoldBagOption) },
 };
 
 export default new GraphQLInterfaceType({

--- a/schema.graphql
+++ b/schema.graphql
@@ -225,6 +225,13 @@ type GeoIP {
   coordinates: Coordinate
 }
 
+type HoldBagOption {
+  quantity: Int
+  price: Price
+  dimensions: String
+  weight: String
+}
+
 """Number of hold bags for a passenger for a given flight"""
 input HoldBags {
   """Flight ID for the bags checked"""
@@ -305,6 +312,7 @@ interface ItineraryInterface {
 
   """Itinerary is valid (exists and is not sold-out or cancelled)"""
   isValid: Boolean
+  holdBagOptions: [HoldBagOption]
 }
 
 """A connection to a list of items."""
@@ -343,6 +351,7 @@ type ItineraryOneWay implements ItineraryInterface & FromToInterface & OneWayInt
 
   """Itinerary is valid (exists and is not sold-out or cancelled)"""
   isValid: Boolean
+  holdBagOptions: [HoldBagOption]
   sector: Sector
 }
 
@@ -375,6 +384,7 @@ type ItineraryReturn implements ItineraryInterface & FromToInterface & ReturnInt
 
   """Itinerary is valid (exists and is not sold-out or cancelled)"""
   isValid: Boolean
+  holdBagOptions: [HoldBagOption]
   outbound: Sector
   inbound: Sector
 }


### PR DESCRIPTION
Extended `Itinerary` object with `HoldBagOptions`.
Tequila bags options are currently slightly limited, because there is only hold bags info available and bookable on Booking endpoints.
This part will be extended later, after more bags options and combinations will be added to endpoints.

Closes: #689 

_Note:_
This part is currently mainly defined/limited by available bags options on booking endpoint, where you can simply just get and book from 1 to 3 hold bags for now.
For now partners should/can use (as it is implemented in this PR): 
- **Search API**: `bags_price`, `baglimit`
- **Booking API**: `bags_price`, `luggage`
(hopefully this mismatching baglimit/luggage naming will be also unified)

After some research I found out that baggage part is currently in active development and should be extended in upcoming weeks. Recent info from baggage team: `Redesign of baggage ordering and the possibility to offer more types of paid baggage - will undergo integration testing in following days`