### PR TITLE
Fix: Date formatting

### DIFF
--- a/apps/core/components/ItineraryCard/LocalTime.js
+++ b/apps/core/components/ItineraryCard/LocalTime.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { type StylePropType, Text } from '@kiwicom/universal-components';
+import { formatDate } from '@kiwicom/margarita-utils';
 
-import { getFormattedDate } from './TripSectorHelpers';
 import type { LocalTime_data as LocalTimeType } from './__generated__/LocalTime_data.graphql';
 
 type Props = {|
@@ -16,7 +16,7 @@ type Props = {|
 function LocalTime({ data, dateFormat, style }: Props) {
   return (
     <Text style={style} numberOfLines={1}>
-      {getFormattedDate(data?.time?.local, dateFormat)}
+      {formatDate(data?.time?.local, dateFormat)}
     </Text>
   );
 }

--- a/apps/core/components/ItineraryCard/TripSectorHelpers.js
+++ b/apps/core/components/ItineraryCard/TripSectorHelpers.js
@@ -1,8 +1,0 @@
-// @flow
-
-import * as DateFNS from 'date-fns';
-import { HOURS_MINUTES_FORMAT } from '@kiwicom/margarita-config';
-
-export const getFormattedDate = (time: ?string, format: ?string) =>
-  time &&
-  DateFNS.format(DateFNS.parseISO(time), format ?? HOURS_MINUTES_FORMAT);

--- a/apps/core/components/sectorDetail/segment/Segment.js
+++ b/apps/core/components/sectorDetail/segment/Segment.js
@@ -10,10 +10,10 @@ import {
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
 import { LONG_DAY_MONTH_FORMAT } from '@kiwicom/margarita-config';
+import { formatDate } from '@kiwicom/margarita-utils';
 
 import SegmentStopInfo from './SegmentStopInfo';
 import { mockCarrierData } from './SegmentConstants';
-import { getFormattedDate } from '../../ItineraryCard/TripSectorHelpers';
 import type { Segment_data as SegmentType } from './__generated__/Segment_data.graphql';
 
 type Props = {|
@@ -21,7 +21,7 @@ type Props = {|
 |};
 
 const Segment = (props: Props) => {
-  const formattedDate = getFormattedDate(
+  const formattedDate = formatDate(
     props.data?.departure?.time?.local,
     LONG_DAY_MONTH_FORMAT,
   );

--- a/apps/core/components/sectorDetail/segment/SegmentStopInfo.js
+++ b/apps/core/components/sectorDetail/segment/SegmentStopInfo.js
@@ -5,9 +5,9 @@ import { View } from 'react-native';
 import { StyleSheet } from '@kiwicom/universal-components';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { graphql, createFragmentContainer } from '@kiwicom/margarita-relay';
+import { formatDate } from '@kiwicom/margarita-utils';
 
 import SegmentStopInfoRow from './SegmentStopInfoRow';
-import { getFormattedDate } from '../../ItineraryCard/TripSectorHelpers';
 import type { SegmentStopInfo_data as RouteStopType } from './__generated__/SegmentStopInfo_data.graphql';
 
 type Props = {|
@@ -27,7 +27,7 @@ const SegmentStopInfo = (props: Props) => {
       <SegmentStopInfoRow
         iconName="clock"
         infoLabel={props.typeLabel}
-        infoText={getFormattedDate(props.data?.time?.local)}
+        infoText={formatDate(props.data?.time?.local)}
       />
     </View>
   );

--- a/apps/core/components/sectorInfo/SectorDate.js
+++ b/apps/core/components/sectorInfo/SectorDate.js
@@ -27,10 +27,10 @@ const SectorDate = (props: Props) => {
   const typeFormat = isDateType ? DAY_MONTH_DATE_FORMAT : HOURS_MINUTES_FORMAT;
   const textSize = isDateType ? 'normal' : 'small';
   const textType = isDateType ? 'primary' : 'secondary';
-  const date = new Date(departureDate);
+
   return (
     <Text size={textSize} type={textType}>
-      {formatDate(date, typeFormat)}
+      {formatDate(departureDate, typeFormat)}
     </Text>
   );
 };

--- a/packages/utils/src/FormatDate/FormatDate.js
+++ b/packages/utils/src/FormatDate/FormatDate.js
@@ -1,12 +1,22 @@
 // @flow
 
-import format from 'date-fns/format';
-import addMinutes from 'date-fns/addMinutes';
+import { format, addMinutes, parseISO } from 'date-fns';
+import { HOURS_MINUTES_FORMAT } from '@kiwicom/margarita-config';
 
-const formatDate = (date: Date, dateFormat: string) => {
-  // Date-fns format adjusts for timezone, we have to remove this
-  // to show correct time/date
-  return format(addMinutes(date, date.getTimezoneOffset()), dateFormat);
+const formatDate = (dateString: ?string, dateFormat: ?string) => {
+  if (dateString == null) {
+    return null;
+  }
+  /**
+   * NOTE: `date-fns` `format` adjusts for timezone,
+   * we have to update date with timezone offset
+   * to show correct time/date
+   */
+  const date = parseISO(dateString);
+  return format(
+    addMinutes(date, date.getTimezoneOffset()),
+    dateFormat ?? HOURS_MINUTES_FORMAT,
+  );
 };
 
 export default formatDate;

--- a/packages/utils/src/FormatDate/__tests__/FormatDate.test.js
+++ b/packages/utils/src/FormatDate/__tests__/FormatDate.test.js
@@ -4,7 +4,8 @@ import { DATE_TIME_FORMAT } from '@kiwicom/margarita-config';
 
 import formatDate from '../FormatDate';
 
-it('formats date correctly', () => {
-  const date = new Date('2018-11-28T16:20:00.000Z');
-  expect(formatDate(date, DATE_TIME_FORMAT)).toEqual('11/28 16:20');
+it('formats iso date correctly', () => {
+  expect(formatDate('2018-11-28T16:20:00.000Z', DATE_TIME_FORMAT)).toEqual(
+    '11/28 16:20',
+  );
 });


### PR DESCRIPTION
- Merged similar function `getFormattedDate` from `ItineraryCard` with `formatDate` inside `utils`.
- Which also fixed wrong time formatting in segments detail. Caused by timezone offset.

Response data:
```
local_departure: '2019-04-27T07:45:00.000Z',
local_arrival: '2019-04-27T08:50:00.000Z',

local_departure: '2019-04-27T13:00:00.000Z',
local_arrival: '2019-04-27T15:55:00.000Z',
```

---

Before
<img width="166" alt="Screenshot 2019-04-24 at 15 43 23" src="https://user-images.githubusercontent.com/2660330/56667762-b8116080-66ae-11e9-8066-7af6cce47195.png">

---

After
<img width="171" alt="Screenshot 2019-04-24 at 15 43 09" src="https://user-images.githubusercontent.com/2660330/56667769-bb0c5100-66ae-11e9-9342-ee96babf795d.png">

---

Same segments on kiwi.com
![Screenshot 2019-04-24 at 15 52 07](https://user-images.githubusercontent.com/2660330/56667711-a203a000-66ae-11e9-8333-c65fefafde10.png)
