### PR TITLE
Feat: Add withHover HOC

### DIFF
--- a/packages/universal-components/README.md
+++ b/packages/universal-components/README.md
@@ -66,8 +66,8 @@ Note: For web projects, you need to ensure you support the `.web.js` extension. 
 
 # Contributing
 
-See [CONTRIBUTING.md](https://github.com/kiwicom/universal-components/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/kiwicom/margarita/blob/master/packages/universal-components/CONTRIBUTING.md)
 
-Repository: <https://github.com/kiwicom/universal-components>
+Repository: <https://github.com/kiwicom/margarita>
 
-Forward your suggestions, issues and bugs [here](https://github.com/kiwicom/universal-components/issues).
+Forward your suggestions, issues and bugs [here](https://github.com/kiwicom/margarita/issues).

--- a/packages/universal-components/src/Hoverable/Hoverable.js
+++ b/packages/universal-components/src/Hoverable/Hoverable.js
@@ -15,6 +15,13 @@ type Props = {|
 const hoverMonitor = HoverMonitor();
 
 class Hoverable extends React.Component<Props> {
+  componentDidMount() {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This component is deprecated and will be removed in a future release. Please use withHover instead',
+    );
+  }
+
   handleOnMouseEnter = () => {
     const { onMouseEnter } = this.props;
     if (onMouseEnter && hoverMonitor.hoverEnabled) {

--- a/packages/universal-components/src/WithHover/__tests__/__snapshots__/withHover.test.js.snap
+++ b/packages/universal-components/src/WithHover/__tests__/__snapshots__/withHover.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Hoverable - native should match snapshot 1`] = `
+<View
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <View
+    isHovered={false}
+    testID="childView"
+  />
+</View>
+`;
+
+exports[`Hoverable - web should match snapshot 1`] = `
+<View
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <View
+    isHovered={false}
+    testID="childView"
+  />
+</View>
+`;

--- a/packages/universal-components/src/WithHover/__tests__/withHover.test.js
+++ b/packages/universal-components/src/WithHover/__tests__/withHover.test.js
@@ -1,0 +1,50 @@
+// @flow
+
+import * as React from 'react';
+import { Platform, View } from 'react-native';
+import { render, fireEvent } from 'react-native-testing-library';
+
+import withHover from '../withHover';
+
+const originalPlatform = Platform.OS;
+
+afterEach(() => {
+  Platform.OS = originalPlatform;
+});
+
+const Hoverable = withHover((props: { isHovered: boolean }) => (
+  <View testID="childView" {...props} />
+));
+
+describe('Hoverable - web', () => {
+  Platform.OS = 'web';
+  const { getByType, getByTestId } = render(<Hoverable />);
+
+  it('should contain children', () => {
+    expect(getByTestId('childView')).toBeDefined();
+  });
+
+  it('should execute onMouseEnter method', () => {
+    fireEvent(getByType(View), 'mouseEnter');
+  });
+
+  it('should execute onMouseLeave method', () => {
+    fireEvent(getByType(View), 'mouseLeave');
+  });
+
+  it('should match snapshot', () => {
+    Platform.OS = 'web';
+    const component = render(<Hoverable />);
+
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe('Hoverable - native', () => {
+  it('should match snapshot', () => {
+    Platform.OS = 'ios';
+    const component = render(<Hoverable />);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/packages/universal-components/src/WithHover/index.js
+++ b/packages/universal-components/src/WithHover/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export { default as withHover } from './withHover';

--- a/packages/universal-components/src/WithHover/withHover.js
+++ b/packages/universal-components/src/WithHover/withHover.js
@@ -1,0 +1,44 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+
+type HoverProps = {
+  +isHovered: boolean,
+};
+
+type WithHoverState = {|
+  +isHovered: boolean,
+|};
+
+export default function withHover<Config: { isHovered: boolean }>(
+  Component: React.AbstractComponent<Config>,
+): React.AbstractComponent<$Diff<Config, HoverProps>> {
+  return class WithHover extends React.Component<
+    $Diff<Config, HoverProps>,
+    WithHoverState,
+  > {
+    state = {
+      isHovered: false,
+    };
+
+    handleOnMouseEnter = () => {
+      this.setState({ isHovered: true });
+    };
+
+    handleOnMouseLeave = () => {
+      this.setState({ isHovered: false });
+    };
+
+    render() {
+      return (
+        <View
+          onMouseEnter={this.handleOnMouseEnter}
+          onMouseLeave={this.handleOnMouseLeave}
+        >
+          <Component {...this.props} isHovered={this.state.isHovered} />
+        </View>
+      );
+    }
+  };
+}

--- a/packages/universal-components/src/WithHover/withHover.stories.js
+++ b/packages/universal-components/src/WithHover/withHover.stories.js
@@ -1,0 +1,43 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { withKnobs } from '@storybook/addon-knobs';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import { StyleSheet } from '../PlatformStyleSheet';
+import withHover from './withHover';
+
+type Props = {|
+  +isHovered: boolean,
+|};
+
+class Square extends React.Component<Props> {
+  render() {
+    return (
+      <View
+        style={[styles.square, this.props.isHovered && styles.squareHovered]}
+      />
+    );
+  }
+}
+
+const HoverableSquare = withHover(Square);
+
+storiesOf('withHover', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    return <HoverableSquare />;
+  });
+
+const styles = StyleSheet.create({
+  square: {
+    width: 50,
+    height: 50,
+    backgroundColor: defaultTokens.backgroundButtonSecondary,
+  },
+  squareHovered: {
+    backgroundColor: defaultTokens.backgroundButtonSecondaryHover,
+  },
+});

--- a/packages/universal-components/src/index.js
+++ b/packages/universal-components/src/index.js
@@ -23,6 +23,7 @@ export { TextInput } from './TextInput';
 export { Tooltip, TooltipBubble } from './Tooltip';
 export { DatePicker } from './DatePicker';
 export { Hoverable } from './Hoverable';
+export { withHover } from './WithHover';
 export { Slider } from './Slider';
 export { Touchable } from './Touchable';
 export { SegmentedButton } from './SegmentedButton';


### PR DESCRIPTION
Summary: withHover HOC will provide us with a better way to check
if a component is hovered. Hoverable implementation was useless
and you had to do the work in each component using it anyways.
Also added a deprecation warning to hoverable component

closes #472