### PR TITLE
Refactor: Remove wrapping view from withHover

### DIFF
--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -30,7 +30,8 @@
     "serverless-offline": "^4.9.4",
     "serverless-webpack": "^5.2.0",
     "uglifyjs-webpack-plugin": "^2.1.2",
-    "webpack": "^4.29.1"
+    "webpack": "^4.29.1",
+    "webpack-node-externals": "^1.7.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.4.4",
@@ -43,8 +44,7 @@
     "serverless": "^1.41.1",
     "serverless-dotenv-plugin": "^2.0.1",
     "utf-8-validate": "^5.0.2",
-    "webpack-cli": "^3.2.3",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-cli": "^3.2.3"
   },
   "peerDependencies": {
     "@babel/preset-flow": "^7.0.0",

--- a/packages/universal-components/src/WithHover/__tests__/__snapshots__/withHover.test.js.snap
+++ b/packages/universal-components/src/WithHover/__tests__/__snapshots__/withHover.test.js.snap
@@ -2,24 +2,18 @@
 
 exports[`Hoverable - native should match snapshot 1`] = `
 <View
+  isHovered={false}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
->
-  <View
-    isHovered={false}
-    testID="childView"
-  />
-</View>
+  testID="childView"
+/>
 `;
 
 exports[`Hoverable - web should match snapshot 1`] = `
 <View
+  isHovered={false}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
->
-  <View
-    isHovered={false}
-    testID="childView"
-  />
-</View>
+  testID="childView"
+/>
 `;

--- a/packages/universal-components/src/WithHover/__tests__/withHover.test.js
+++ b/packages/universal-components/src/WithHover/__tests__/withHover.test.js
@@ -12,9 +12,13 @@ afterEach(() => {
   Platform.OS = originalPlatform;
 });
 
-const Hoverable = withHover((props: { isHovered: boolean }) => (
-  <View testID="childView" {...props} />
-));
+const Hoverable = withHover(
+  (props: {
+    isHovered: boolean,
+    onMouseEnter: () => void,
+    onMouseLeave: () => void,
+  }) => <View testID="childView" {...props} />,
+);
 
 describe('Hoverable - web', () => {
   Platform.OS = 'web';

--- a/packages/universal-components/src/WithHover/withHover.js
+++ b/packages/universal-components/src/WithHover/withHover.js
@@ -1,17 +1,18 @@
 // @flow
 
 import * as React from 'react';
-import { View } from 'react-native';
 
 type HoverProps = {
   +isHovered: boolean,
+  +onMouseEnter: () => void,
+  +onMouseLeave: () => void,
 };
 
 type WithHoverState = {|
   +isHovered: boolean,
 |};
 
-export default function withHover<Config: { isHovered: boolean }>(
+export default function withHover<Config: HoverProps>(
   Component: React.AbstractComponent<Config>,
 ): React.AbstractComponent<$Diff<Config, HoverProps>> {
   return class WithHover extends React.Component<
@@ -32,12 +33,12 @@ export default function withHover<Config: { isHovered: boolean }>(
 
     render() {
       return (
-        <View
+        <Component
+          {...this.props}
+          isHovered={this.state.isHovered}
           onMouseEnter={this.handleOnMouseEnter}
           onMouseLeave={this.handleOnMouseLeave}
-        >
-          <Component {...this.props} isHovered={this.state.isHovered} />
-        </View>
+        />
       );
     }
   };

--- a/packages/universal-components/src/WithHover/withHover.stories.js
+++ b/packages/universal-components/src/WithHover/withHover.stories.js
@@ -11,13 +11,17 @@ import withHover from './withHover';
 
 type Props = {|
   +isHovered: boolean,
+  +onMouseEnter: () => void,
+  +onMouseLeave: () => void,
 |};
 
 class Square extends React.Component<Props> {
   render() {
+    const { isHovered, ...rest } = this.props;
     return (
       <View
-        style={[styles.square, this.props.isHovered && styles.squareHovered]}
+        style={[styles.square, isHovered && styles.squareHovered]}
+        {...rest}
       />
     );
   }


### PR DESCRIPTION
Summary:Wrapping view caused malformed style when applied to components.
Instead inject the onMouseLeave and onMouseEnter through the HOC.

