### PR TITLE
Docs: Removed 'Need help' section

### DIFF
--- a/apps/documentation/i18n/en.json
+++ b/apps/documentation/i18n/en.json
@@ -49,10 +49,6 @@
         "title": "What is this all about?",
         "sidebar_label": "What is this all about?"
       },
-      "need-help": {
-        "title": "Need help?",
-        "sidebar_label": "Need help?"
-      },
       "packages/index": {
         "title": "List of Packages",
         "sidebar_label": "List of Packages"

--- a/apps/documentation/sidebars.json
+++ b/apps/documentation/sidebars.json
@@ -11,7 +11,6 @@
     "Developing": [
       "getting-started",
       "contributing",
-      "need-help",
       "folder-structure",
       "technical-overview",
       "guide-tequila-api-key"

--- a/docs/need-help.md
+++ b/docs/need-help.md
@@ -1,6 +1,0 @@
----
-title: Need help?
-sidebar_label: Need help?
----
-
-_This page is a stub._


### PR DESCRIPTION
Sections removed because it looks duplicate to existing questions related section https://kiwicom.github.io/margarita/docs/questions-bugs-feature-requests

Maybe we can add some FAQ section later. But we will need to really gather some real questions first.

Closes #542