### PR TITLE
Feat: Make whole body scrollable when there are search results (On web with mobile res)

### DIFF
--- a/apps/core/scenes/results/Results.js
+++ b/apps/core/scenes/results/Results.js
@@ -165,6 +165,7 @@ class Results extends React.Component<Props> {
       },
     };
     const desktopLayout = this.props.layout >= LAYOUT.desktop;
+    const mobileLayout = this.props.layout < LAYOUT.largeMobile;
     return (
       <SafeAreaView style={styles.container}>
         {Platform.OS === 'web' ? (
@@ -192,7 +193,12 @@ class Results extends React.Component<Props> {
           />
         )}
 
-        <View style={styles.resultContainer}>
+        <View
+          style={[
+            styles.resultContainer,
+            !mobileLayout && styles.flexContainer,
+          ]}
+        >
           <SortTabsWrapper />
           <QueryComponent {...props} />
         </View>
@@ -204,6 +210,8 @@ class Results extends React.Component<Props> {
 const styles = StyleSheet.create({
   resultContainer: {
     backgroundColor: defaultTokens.backgroundBody,
+  },
+  flexContainer: {
     flex: 1,
   },
   container: {

--- a/apps/core/scenes/results/ResultsList.js
+++ b/apps/core/scenes/results/ResultsList.js
@@ -66,6 +66,7 @@ export default createFragmentContainer(ResultsList, {
 
 const styles = StyleSheet.create({
   container: {
+    backgroundColor: defaultTokens.backgroundBody,
     paddingTop: parseInt(defaultTokens.spaceXSmall, 10),
     web: {
       paddingTop: parseInt(defaultTokens.spaceMedium, 10),

--- a/apps/web/components/Layout.js
+++ b/apps/web/components/Layout.js
@@ -34,7 +34,9 @@ export const Layout = ({ layoutReady, children }: Props) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    overflow: 'hidden',
+    web: {
+      overflow: 'auto',
+    },
   },
 });
 

--- a/apps/web/components/__tests__/Layout.test.js
+++ b/apps/web/components/__tests__/Layout.test.js
@@ -14,22 +14,21 @@ it('renders', () => {
       </Layout>,
     ),
   ).toMatchInlineSnapshot(`
-Object {
-  "output": <Component
-    style={
-      Object {
-        "flex": 1,
-        "overflow": "hidden",
-      }
+    Object {
+      "output": <Component
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <React.Fragment>
+          <Navbar />
+          <Component />
+        </React.Fragment>
+      </Component>,
     }
-  >
-    <React.Fragment>
-      <Navbar />
-      <Component />
-    </React.Fragment>
-  </Component>,
-}
-`);
+  `);
 });
 
 it('renders with multiple children', () => {
@@ -41,21 +40,20 @@ it('renders with multiple children', () => {
       </Layout>,
     ),
   ).toMatchInlineSnapshot(`
-Object {
-  "output": <Component
-    style={
-      Object {
-        "flex": 1,
-        "overflow": "hidden",
-      }
+    Object {
+      "output": <Component
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <React.Fragment>
+          <Navbar />
+          <Component />
+          <Component />
+        </React.Fragment>
+      </Component>,
     }
-  >
-    <React.Fragment>
-      <Navbar />
-      <Component />
-      <Component />
-    </React.Fragment>
-  </Component>,
-}
-`);
+  `);
 });

--- a/packages/universal-components/src/PlatformStyleSheet/StyleTypes.js
+++ b/packages/universal-components/src/PlatformStyleSheet/StyleTypes.js
@@ -49,6 +49,7 @@ export type PlatformStyleObjectType = {
       web: {
         ...ReducedDangerouslyImpreciseStyle,
         position?: 'absolute' | 'relative' | 'fixed',
+        overflow?: 'visible' | 'hidden' | 'scroll' | 'auto',
       }, // might need to be expanded
     },
   >,


### PR DESCRIPTION
Fixes #732 . Make all the body scrollable when there are search results instead of just the flat list, only in web version with mobile resolution. This allows seeing the results (before only a small frame appeared)