### PR TITLE
Fix: Results flex style condition on mobile

### DIFF
--- a/apps/core/scenes/results/Results.js
+++ b/apps/core/scenes/results/Results.js
@@ -164,11 +164,12 @@ class Results extends React.Component<Props> {
         input: this.parseSearchParametersByType(tripType),
       },
     };
+    const isWeb = Platform.OS === 'web';
     const desktopLayout = this.props.layout >= LAYOUT.desktop;
-    const mobileLayout = this.props.layout < LAYOUT.largeMobile;
+    const mobileWebLayout = isWeb && this.props.layout < LAYOUT.largeMobile;
     return (
       <SafeAreaView style={styles.container}>
-        {Platform.OS === 'web' ? (
+        {isWeb ? (
           <View
             style={[
               styles.searchFormContainer,
@@ -196,7 +197,7 @@ class Results extends React.Component<Props> {
         <View
           style={[
             styles.resultContainer,
-            !mobileLayout && styles.flexContainer,
+            !mobileWebLayout && styles.flexContainer,
           ]}
         >
           <SortTabsWrapper />

--- a/apps/core/scenes/results/__tests__/__snapshots__/ResultsList.test.js.snap
+++ b/apps/core/scenes/results/__tests__/__snapshots__/ResultsList.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`renders 1`] = `
 <RCTScrollView
-  contentContainerStyle={Object {}}
+  contentContainerStyle={
+    Object {
+      "backgroundColor": "#f5f7f9",
+      "paddingTop": 8,
+    }
+  }
   data={
     Array [
       Object {


### PR DESCRIPTION
Updated style condition added in #735 , which unintentionally disabled flex layout also in mobile version.
Flex layout is correctly disabled only for mobile web version in updated version.

Before

<img width="391" alt="Screenshot 2019-05-03 at 16 26 02" src="https://user-images.githubusercontent.com/2660330/57144296-0fa38080-6dc1-11e9-8870-9cf31fc42419.png">

After

<img width="383" alt="Screenshot 2019-05-03 at 16 22 29" src="https://user-images.githubusercontent.com/2660330/57144291-0c0ff980-6dc1-11e9-968e-1025f424dbc1.png">
