### PR TITLE
Feat: Hide insurance info on PassengerCard

### DIFF
--- a/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailPassenger.js
+++ b/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailPassenger.js
@@ -23,7 +23,6 @@ const passengerCards = [
     nationality: 'Russian',
     dateOfBirth: '22/04/1980',
     id: 'DF45SV8',
-    insurance: 'Travel Insurance Name',
     passengerCount: 1,
     bags: [
       { count: 2, type: '40x15x30cm, 3kg' },

--- a/packages/components/src/passengerCard/PassengerCard.js
+++ b/packages/components/src/passengerCard/PassengerCard.js
@@ -44,7 +44,6 @@ class PassengerCard extends React.Component<Props> {
     nationality: '',
     dateOfBirth: '',
     id: '',
-    insurance: '',
     bags: null,
   };
 
@@ -106,11 +105,6 @@ class PassengerCard extends React.Component<Props> {
           </View>
           <Separator />
           <View style={styles.containerBottom}>
-            <PassengerCardDetail
-              value={insurance}
-              label="Travel Insurance"
-              style="normal"
-            />
             <View style={styles.bagsRowWrapper}>
               <Text type="secondary" style={styles.textPadding}>
                 Bags
@@ -126,6 +120,13 @@ class PassengerCard extends React.Component<Props> {
                   ))}
               </View>
             </View>
+            {insurance != null && (
+              <PassengerCardDetail
+                value={insurance}
+                label="Travel Insurance"
+                style="normal"
+              />
+            )}
           </View>
         </Card>
         {visaRequired != null && <VisaInfo visaRequired={visaRequired} />}

--- a/packages/components/src/passengerCard/PassengerCardTypes.js
+++ b/packages/components/src/passengerCard/PassengerCardTypes.js
@@ -13,7 +13,7 @@ export type PassengerCardType = {|
   +nationality: string,
   +dateOfBirth: string,
   +id: string,
-  +insurance: string,
+  +insurance?: ?string,
   +bags: null | Array<Bag>,
   +passengerCount: number,
   +visaRequired?: ?boolean,

--- a/packages/components/src/passengerCard/__tests__/__snapshots__/PassengerCard.test.js.snap
+++ b/packages/components/src/passengerCard/__tests__/__snapshots__/PassengerCard.test.js.snap
@@ -70,11 +70,6 @@ Object {
           }
         }
       >
-        <PassengerCardDetail
-          label="Travel Insurance"
-          style="normal"
-          value=""
-        />
         <Component
           style={
             Object {
@@ -170,11 +165,6 @@ Object {
           }
         }
       >
-        <PassengerCardDetail
-          label="Travel Insurance"
-          style="normal"
-          value="Travel Inusurance Name"
-        />
         <Component
           style={
             Object {
@@ -203,6 +193,11 @@ Object {
             />
           </Component>
         </Component>
+        <PassengerCardDetail
+          label="Travel Insurance"
+          style="normal"
+          value="Travel Inusurance Name"
+        />
       </Component>
     </Card>
   </Component>,


### PR DESCRIPTION
Made insurance info optional and information block is rendered only if any insurance info is present in passenger data.
Insurance is currently not available for Tequila partners and this feature is currently not planned.
(but if it will be available one day, we will be ready)

<img width="381" alt="Screenshot 2019-05-03 at 16 58 24" src="https://user-images.githubusercontent.com/2660330/57146043-b9d0d780-6dc4-11e9-8379-3ed49c63582e.png">
