### PR TITLE
Chore: change to test deploying graphql with env variables with CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Deploy GraphQL lambda
-          command: BASE_URL=$BASE_URL API_KEY=$API_KEY yarn graphql:deploy
+          command: BASE_URL=$BASE_URL API_KEY=$API_KEY yarn workspace @kiwicom/margarita-graphql deploy
 
   build-and-deploy-documentation:
     <<: *defaults

--- a/apps/graphql/src/apps/itinerary/types/inputs/common/ItineraryCommonSearchInputFields.js
+++ b/apps/graphql/src/apps/itinerary/types/inputs/common/ItineraryCommonSearchInputFields.js
@@ -16,7 +16,8 @@ export default {
     type: SortSearchInput,
   },
   limit: {
-    description: 'Limit of results to get from the search (maximum 200)',
+    description:
+      'Limit of the number of results to get from the search (maximum 200)',
     type: GraphQLInt,
   },
   passengers: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -263,7 +263,7 @@ input ItinerariesOneWaySearchInput {
   """Sorting of the search"""
   sort: SortSearchInput
 
-  """Limit of results to get from the search (maximum 200)"""
+  """Limit of the number of results to get from the search (maximum 200)"""
   limit: Int
 
   """How many passengers are travelling"""
@@ -280,7 +280,7 @@ input ItinerariesReturnSearchInput {
   """Sorting of the search"""
   sort: SortSearchInput
 
-  """Limit of results to get from the search (maximum 200)"""
+  """Limit of the number of results to get from the search (maximum 200)"""
   limit: Int
 
   """How many passengers are travelling"""


### PR DESCRIPTION
Change to trigger GraphQL server build on CircleCI with `env` variables set via CLI from the circleCI env variables so `serverless.yml` can get them (instead of getting them from a non-existent `.env` file)