### PR TITLE
Chore: Generate custom .env file for GraphQL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
             sudo npm i -g serverless
             yarn install
       - run:
-          name: Add .env file
-          command: yarn create-dotenv
+          name: Generate .env file for GraphQL
+          command: echo BASE_URL=$BASE_URL >> .env && echo API_KEY=$API_KEY >> .env
       - run:
           name: Copy .env file to graphql folder
           command: cp ~/margarita/.env ~/margarita/apps/graphql

--- a/apps/graphql/src/apps/itinerary/types/inputs/common/ItineraryCommonSearchInputFields.js
+++ b/apps/graphql/src/apps/itinerary/types/inputs/common/ItineraryCommonSearchInputFields.js
@@ -16,7 +16,7 @@ export default {
     type: SortSearchInput,
   },
   limit: {
-    description: 'Limit of results to get from the search (maximum 200)',
+    description: 'Limit number of results to get from the search (maximum 200)',
     type: GraphQLInt,
   },
   passengers: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -263,7 +263,7 @@ input ItinerariesOneWaySearchInput {
   """Sorting of the search"""
   sort: SortSearchInput
 
-  """Limit of results to get from the search (maximum 200)"""
+  """Limit number of results to get from the search (maximum 200)"""
   limit: Int
 
   """How many passengers are travelling"""
@@ -280,7 +280,7 @@ input ItinerariesReturnSearchInput {
   """Sorting of the search"""
   sort: SortSearchInput
 
-  """Limit of results to get from the search (maximum 200)"""
+  """Limit number of results to get from the search (maximum 200)"""
   limit: Int
 
   """How many passengers are travelling"""


### PR DESCRIPTION
Generating only the necessary fields on the `.env` to not overflow the limit set by AWS Lambda on environment variables (4kb)