### PR TITLE
Feature: Add anywhere text when no location selected on PlacePicker

### DIFF
--- a/apps/core/components/searchForm/SearchForm.js
+++ b/apps/core/components/searchForm/SearchForm.js
@@ -76,7 +76,7 @@ class SearchForm extends React.Component<Props> {
     } = this.props;
     if (travelFrom == null || travelFrom.length === 0) {
       this.props.setAlertContent({
-        message: 'Please fill this form completely before you proceed',
+        message: 'Please choose an origin place',
       });
     } else {
       const dateFrom = format(this.props.dateFrom, BASIC_ISO_DATE_FORMAT);

--- a/packages/components/src/tripInput/TripInput.js
+++ b/packages/components/src/tripInput/TripInput.js
@@ -22,6 +22,10 @@ type Props = {|
   +placeholder?: string,
 |};
 
+const getEmptyLocationPlaceholder = (field: string): string => {
+  return field === 'From' ? '' : 'Anywhere';
+};
+
 export default function TripInput({
   style,
   icon,
@@ -33,16 +37,23 @@ export default function TripInput({
   const inputIcon = React.cloneElement(icon, {
     color: defaultTokens.colorIconSecondary,
   });
+  const hasValue = value.length > 0;
   return (
     <TouchableWithoutFeedback onPress={onPress}>
-      <View style={[styles.container, style]}>
+      <View
+        style={[
+          styles.container,
+          !hasValue && label === 'From' && styles.warningContainer,
+          style,
+        ]}
+      >
         {Platform.OS !== 'web' && <View style={styles.icon}>{inputIcon}</View>}
         <Text style={styles.label}>{label.length > 0 ? `${label}: ` : ''}</Text>
-        {value !== '' && (
+        {
           <Text numberOfLines={1} ellipsizeMode="clip" style={styles.value}>
-            {value}
+            {hasValue ? value : getEmptyLocationPlaceholder(label)}
           </Text>
-        )}
+        }
         {value === '' && placeholder != null && <Text>{placeholder}</Text>}
       </View>
     </TouchableWithoutFeedback>
@@ -65,6 +76,9 @@ const styles = StyleSheet.create({
       borderWidth: 1,
       borderColor: defaultTokens.paletteInkLighter,
     },
+  },
+  warningContainer: {
+    borderColor: defaultTokens.paletteRedNormal,
   },
   icon: {
     marginEnd: 10,

--- a/packages/components/src/tripInput/__tests__/__snapshots__/TripInput.test.js.snap
+++ b/packages/components/src/tripInput/__tests__/__snapshots__/TripInput.test.js.snap
@@ -18,6 +18,7 @@ Object {
             "marginBottom": 8,
             "padding": 11,
           },
+          false,
           undefined,
         ]
       }
@@ -76,6 +77,7 @@ Object {
             "marginBottom": 8,
             "padding": 11,
           },
+          false,
           undefined,
         ]
       }
@@ -134,6 +136,7 @@ Object {
             "marginBottom": 8,
             "padding": 11,
           },
+          false,
           undefined,
         ]
       }
@@ -157,6 +160,17 @@ Object {
         }
       >
         label: 
+      </Text>
+      <Text
+        ellipsizeMode="clip"
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#171b1e",
+          }
+        }
+      >
+        Anywhere
       </Text>
       <Text>
         placeholder


### PR DESCRIPTION
Anywhere is placed instead on the PlacePickers when no place is selected. Due to limitations on `Tequila`, both places can't be empty at the same time but one of them can (either destination or origin), so a check that both aren't empty is performed on submit. Closes #766 

![May-13-2019 17-25-33](https://user-images.githubusercontent.com/11021461/57633708-31142180-75a4-11e9-81c6-0c2467a0d715.gif)
