### PR TITLE
GraphQL: Playground has light theme by default

### DIFF
--- a/apps/graphql/src/server.js
+++ b/apps/graphql/src/server.js
@@ -32,6 +32,9 @@ const server = new ApolloServer({
   },
   playground: {
     endpoint: playgroundEndpoint,
+    settings: {
+      'editor.theme': 'light',
+    },
   },
   introspection: true,
 });


### PR DESCRIPTION
This is necessary for the landing page of Margarita