### PR TITLE
Refactor: Remove mock passenger data

### DIFF
--- a/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailPassenger.js
+++ b/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailPassenger.js
@@ -57,8 +57,9 @@ class ResultDetailPassenger extends React.Component<Props, State> {
 
   handleFormSaveRequest = passenger => {
     const errorMessage = this.validateForm(passenger);
+    const { setAlertContent } = this.props;
     if (errorMessage) {
-      this.props.setAlertContent({
+      setAlertContent({
         message: errorMessage,
       });
     } else {

--- a/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailPassenger.js
+++ b/apps/core/scenes/resultDetail/resultDetailContent/ResultDetailPassenger.js
@@ -24,64 +24,10 @@ type State = {|
   +currentEditID: ?string,
 |};
 
-// @TODO: This data should not be mocked in the future. Remove it.
-const defaultPassengers = [
-  {
-    name: 'John',
-    lastName: 'Doe',
-    gender: 'male',
-    nationality: 'Russian',
-    dateOfBirth: new Date('1980-06-22'),
-    id: 'DF45SV8',
-    passengerCount: 1,
-    bags: [
-      {
-        quantity: 2,
-        dimensions: '28 x 52 x 78 cm',
-        weight: '20 kg',
-        price: {
-          amount: 84,
-          currency: 'EUR',
-        },
-      },
-      {
-        quantity: 1,
-        dimensions: '28 x 52 x 78 cm',
-        weight: '20 kg',
-        price: {
-          amount: 84,
-          currency: 'EUR',
-        },
-      },
-    ],
-  },
-  {
-    name: 'Jana',
-    lastName: 'Nováková',
-    gender: 'female',
-    nationality: 'Czech',
-    dateOfBirth: new Date('1984-06-12'),
-    id: 'DF45SV9',
-    insurance: 'Travel Insurance Name',
-    passengerCount: 1,
-    bags: [
-      {
-        quantity: 1,
-        dimensions: '28 x 52 x 78 cm',
-        weight: '20 kg',
-        price: {
-          amount: 84,
-          currency: 'EUR',
-        },
-      },
-    ],
-  },
-];
-
 class ResultDetailPassenger extends React.Component<Props, State> {
   state = {
     isFormVisible: false,
-    passengerData: defaultPassengers,
+    passengerData: [],
     currentEditID: '',
   };
 


### PR DESCRIPTION
Closes #790 . Also, added validation that at least one passenger is required before going into the `Payment` screen of the booking process.