### PR TITLE
Possibility of picking history dates in RangeDatePicker

### DIFF
--- a/apps/core/components/searchForm/DatePicker.js
+++ b/apps/core/components/searchForm/DatePicker.js
@@ -131,7 +131,7 @@ class DatePicker extends React.Component<Props, State> {
           label={label}
           buttonLabels={buttonLabels}
           numberOfRenderedMonths={numberOfRenderedMonths}
-          weekStartsOn={weekStartsOn ?? 1}
+          weekStartsOn={weekStartsOn}
           dateFormat={LONG_DAY_MONTH_FORMAT}
           isNightsInDestinationVisible={isNightsInDestinationVisible}
           nightsInDestination={this.state.tempNightsInDestination}

--- a/packages/universal-components/src/RangeDatePicker/RangeDatePicker.js
+++ b/packages/universal-components/src/RangeDatePicker/RangeDatePicker.js
@@ -13,8 +13,6 @@ import NightsInDestination from './NightsInDestination';
 import ControlContainer from './components/ControlContainer';
 
 export default class RangeDatePicker extends React.Component<Props> {
-  // @TODO load price for days
-
   static defaultProps = {
     isNightsInDestinationVisible: false,
     isNightsInDestinationSelected: false,
@@ -52,6 +50,7 @@ export default class RangeDatePicker extends React.Component<Props> {
 
   render() {
     const {
+      isChoosingPastDatesEnabled,
       isVisible,
       label,
       buttonLabels,
@@ -65,6 +64,7 @@ export default class RangeDatePicker extends React.Component<Props> {
       nightsInDestinationLabel,
       isNightsInDestinationSelected,
       isControlContainerVisible,
+      renderFirstMonthFrom,
     } = this.props;
 
     return (
@@ -76,11 +76,13 @@ export default class RangeDatePicker extends React.Component<Props> {
         <View style={styles.content}>
           {!isNightsInDestinationSelected || !isNightsInDestinationVisible ? (
             <RangeDatePickerContent
+              isChoosingPastDatesEnabled={isChoosingPastDatesEnabled ?? false}
               selectedDates={this.props.dates}
               onDayPress={this.handleChangeDate}
               numberOfRenderedMonths={numberOfRenderedMonths}
-              weekStartsOn={weekStartsOn}
+              weekStartsOn={weekStartsOn ?? 1}
               isRangePicker={isRangePicker ?? true}
+              renderFirstMonthFrom={renderFirstMonthFrom ?? new Date()}
             />
           ) : (
             <NightsInDestination

--- a/packages/universal-components/src/RangeDatePicker/RangeDatePicker.stories.js
+++ b/packages/universal-components/src/RangeDatePicker/RangeDatePicker.stories.js
@@ -77,6 +77,11 @@ class RangeDatePickerStory extends React.Component<Props, State> {
   };
 
   render() {
+    const isChoosingPastDatesEnabled = boolean(
+      'isChoosingPastDatesEnabled',
+      false,
+      'config',
+    );
     const isRangePicker = boolean('isRangePicker', true, 'config');
     const isNightsInDestinationVisible = boolean(
       'isNightsInDestinationVisible',
@@ -104,7 +109,9 @@ class RangeDatePickerStory extends React.Component<Props, State> {
       },
       'labels',
     );
+
     const numberOfRenderedMonths = 6;
+    const renderFirstMonthFrom = new Date();
 
     return (
       <>
@@ -113,6 +120,8 @@ class RangeDatePickerStory extends React.Component<Props, State> {
           label="Open RangeDatePicker"
         />
         <RangeDatePicker
+          renderFirstMonthFrom={renderFirstMonthFrom}
+          isChoosingPastDatesEnabled={isChoosingPastDatesEnabled}
           isVisible={this.state.isVisible}
           isControlContainerVisible={isControlContainerVisible}
           dates={this.state.tempDates}

--- a/packages/universal-components/src/RangeDatePicker/RangeDatePickerContent.js
+++ b/packages/universal-components/src/RangeDatePicker/RangeDatePickerContent.js
@@ -19,6 +19,8 @@ type Props = {|
   +numberOfRenderedMonths: number,
   +weekStartsOn: WeekStartsType,
   +isRangePicker: boolean,
+  +renderFirstMonthFrom: Date,
+  +isChoosingPastDatesEnabled: boolean,
 |};
 
 type State = {|
@@ -32,7 +34,12 @@ export default class RangeDatePickerContent extends React.Component<
   constructor(props: Props) {
     super(props);
     this.state = {
-      nextMonths: getMonths(props.numberOfRenderedMonths, props.weekStartsOn),
+      nextMonths: getMonths({
+        numberOfRenderedMonths: props.numberOfRenderedMonths,
+        weekStartsOn: props.weekStartsOn,
+        whichMonthsToRender: 'next',
+        renderFirstMonthFrom: props.renderFirstMonthFrom,
+      }),
     };
   }
 
@@ -49,13 +56,21 @@ export default class RangeDatePickerContent extends React.Component<
     }, 0);
 
   renderMonthItem = ({ item }: {| +item: MonthDateType |}) => {
+    const {
+      onDayPress,
+      selectedDates,
+      weekStartsOn,
+      isRangePicker,
+      isChoosingPastDatesEnabled,
+    } = this.props;
     return (
       <RenderMonth
         monthDate={item}
-        onDayPress={this.props.onDayPress}
-        selectedDates={this.props.selectedDates}
-        weekStartsOn={this.props.weekStartsOn}
-        isRangePicker={this.props.isRangePicker}
+        onDayPress={onDayPress}
+        selectedDates={selectedDates}
+        weekStartsOn={weekStartsOn}
+        isRangePicker={isRangePicker}
+        isChoosingPastDatesEnabled={isChoosingPastDatesEnabled}
       />
     );
   };
@@ -94,7 +109,11 @@ export default class RangeDatePickerContent extends React.Component<
               data={this.state.nextMonths}
               keyExtractor={this.keyExtractor}
               renderItem={this.renderMonthItem}
-              extraData={this.props.selectedDates}
+              extraData={[
+                this.props.selectedDates,
+                this.props.isChoosingPastDatesEnabled,
+                this.props.isRangePicker,
+              ]}
               initialNumToRender={2}
               style={styles.flatList}
               getItemLayout={this.getFlatListLayout}

--- a/packages/universal-components/src/RangeDatePicker/RangeDatePickerTypes.js
+++ b/packages/universal-components/src/RangeDatePicker/RangeDatePickerTypes.js
@@ -9,6 +9,8 @@ export type ConfirmType = {|
 |};
 
 export type Props = {|
+  +renderFirstMonthFrom?: Date,
+  +isChoosingPastDatesEnabled?: boolean,
   +isVisible: boolean,
   +dates: $ReadOnlyArray<Date>,
   +onConfirm: ConfirmType => void,
@@ -17,7 +19,7 @@ export type Props = {|
   +isRangePicker?: boolean,
   +isControlContainerVisible?: boolean,
   +numberOfRenderedMonths: number,
-  +weekStartsOn: WeekStartsType,
+  +weekStartsOn?: WeekStartsType,
   +label: string,
   +dateFormat: string,
   +isNightsInDestinationVisible?: boolean,
@@ -59,6 +61,7 @@ export type FindRelatedItemConfigType = {|
   +dayItemSize: DayItemSizeType,
   +grabbedSide: GrabbedSideType,
   +weekStartsOn: WeekStartsType,
+  +isChoosingPastDatesEnabled: boolean,
 |};
 
 export type XY = {

--- a/packages/universal-components/src/RangeDatePicker/__tests__/libs.test.js
+++ b/packages/universal-components/src/RangeDatePicker/__tests__/libs.test.js
@@ -71,18 +71,18 @@ describe('RangeDatePicker ', () => {
   });
 
   it('getMonths should get array of info about previous or next months', () => {
-    const prevMonths = getMonths(
-      4,
-      weekStartsOnMonday,
-      'prev',
-      new Date(2019, 4, 1),
-    );
-    const nextMonths = getMonths(
-      2,
-      weekStartsOnSunday,
-      undefined,
-      new Date(2019, 2, 1),
-    );
+    const prevMonths = getMonths({
+      numberOfRenderedMonths: 4,
+      weekStartsOn: weekStartsOnMonday,
+      whichMonthsToRender: 'prev',
+      renderFirstMonthFrom: new Date(2019, 4, 1),
+    });
+    const nextMonths = getMonths({
+      numberOfRenderedMonths: 2,
+      weekStartsOn: weekStartsOnSunday,
+      whichMonthsToRender: undefined,
+      renderFirstMonthFrom: new Date(2019, 2, 1),
+    });
     expect(prevMonths).toMatchObject([
       {
         month: 1,

--- a/packages/universal-components/src/RangeDatePicker/components/DraggableItem.ios.js
+++ b/packages/universal-components/src/RangeDatePicker/components/DraggableItem.ios.js
@@ -11,9 +11,10 @@ import type { GrabbedSideType, XY } from '../RangeDatePickerTypes';
 import type { OnDragEvent, OnDropEvent } from '../../types';
 
 type Props = {
-  +onDrag: (OnDragEvent, GrabbedSideType) => void,
+  +onDrag: (OnDragEvent, GrabbedSideType, boolean) => void,
   +onDrop: () => void,
   +grabbedSide: GrabbedSideType,
+  +isChoosingPastDatesEnabled: boolean,
 };
 
 export default class DraggableItem extends React.Component<Props> {
@@ -44,7 +45,11 @@ export default class DraggableItem extends React.Component<Props> {
   onGestureEvent: OnDragEvent;
 
   onDrag = (event: OnDragEvent) => {
-    this.props.onDrag(event, this.props.grabbedSide);
+    this.props.onDrag(
+      event,
+      this.props.grabbedSide,
+      this.props.isChoosingPastDatesEnabled,
+    );
   };
 
   onHandlerStateChange = (event: OnDropEvent) => {

--- a/packages/universal-components/src/RangeDatePicker/components/DraggableItem.web.js
+++ b/packages/universal-components/src/RangeDatePicker/components/DraggableItem.web.js
@@ -11,11 +11,12 @@ import type { GrabbedSideType, DayItemSizeType } from '../RangeDatePickerTypes';
 import type { OnDragEvent } from '../../types';
 
 type Props = {
-  +onDrag: (OnDragEvent, GrabbedSideType) => void,
+  +onDrag: (OnDragEvent, GrabbedSideType, boolean) => void,
   +onDrop: () => void,
   +onPress: () => void,
   +grabbedSide: GrabbedSideType,
   +dayItemSize: DayItemSizeType,
+  +isChoosingPastDatesEnabled: boolean,
 };
 
 export default class DraggableItem extends React.Component<Props> {
@@ -30,6 +31,7 @@ export default class DraggableItem extends React.Component<Props> {
         },
       },
       this.props.grabbedSide,
+      this.props.isChoosingPastDatesEnabled,
     );
   };
 

--- a/packages/universal-components/src/RangeDatePicker/components/RenderMonth.js
+++ b/packages/universal-components/src/RangeDatePicker/components/RenderMonth.js
@@ -21,6 +21,7 @@ type Props = {|
   +selectedDates: $ReadOnlyArray<Date>,
   +weekStartsOn: WeekStartsType,
   +isRangePicker: boolean,
+  +isChoosingPastDatesEnabled: boolean,
 |};
 
 const checkDatesForComponentUpdate = props => {
@@ -43,7 +44,9 @@ export default class RenderMonth extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
     return (
       checkDatesForComponentUpdate(nextProps) ||
-      checkDatesForComponentUpdate(this.props)
+      checkDatesForComponentUpdate(this.props) ||
+      this.props.isChoosingPastDatesEnabled !==
+        nextProps.isChoosingPastDatesEnabled
     );
   }
 
@@ -62,6 +65,7 @@ export default class RenderMonth extends React.Component<Props> {
       selectedDates,
       isRangePicker,
       weekStartsOn,
+      isChoosingPastDatesEnabled,
     } = this.props;
     const keyPrefix = `${this.props.monthDate.year}-${
       this.props.monthDate.month
@@ -84,6 +88,7 @@ export default class RenderMonth extends React.Component<Props> {
             selectedDates={selectedDates}
             isRangePicker={isRangePicker}
             weekStartsOn={weekStartsOn}
+            isChoosingPastDatesEnabled={isChoosingPastDatesEnabled}
           />
         ))}
       </View>

--- a/packages/universal-components/src/RangeDatePicker/components/RenderWeek.js
+++ b/packages/universal-components/src/RangeDatePicker/components/RenderWeek.js
@@ -14,6 +14,7 @@ type Props = {|
   +selectedDates: $ReadOnlyArray<Date>,
   +isRangePicker: boolean,
   +weekStartsOn: WeekStartsType,
+  +isChoosingPastDatesEnabled: boolean,
 |};
 
 export default function RenderWeek({
@@ -23,6 +24,7 @@ export default function RenderWeek({
   selectedDates,
   isRangePicker,
   weekStartsOn,
+  isChoosingPastDatesEnabled,
 }: Props) {
   return (
     <View style={styles.row}>
@@ -35,6 +37,7 @@ export default function RenderWeek({
             selectedDates={selectedDates}
             isRangePicker={isRangePicker}
             weekStartsOn={weekStartsOn}
+            isChoosingPastDatesEnabled={isChoosingPastDatesEnabled}
           />
         );
       })}

--- a/packages/universal-components/src/RangeDatePicker/libs.js
+++ b/packages/universal-components/src/RangeDatePicker/libs.js
@@ -74,24 +74,31 @@ export const getMonthMatrix = (
   );
 };
 
-export const getMonths = (
-  numberOfMonths: number,
+export const getMonths = ({
+  numberOfRenderedMonths,
+  weekStartsOn,
+  whichMonthsToRender = 'next',
+  renderFirstMonthFrom = new Date(),
+}: {
+  numberOfRenderedMonths: number,
   weekStartsOn: WeekStartsType,
-  whichMonthsToRender: 'prev' | 'next' = 'next',
-  startDate: Date = new Date(),
-): Array<MonthDateType> =>
-  new Array(Math.abs(numberOfMonths)).fill(undefined).map((_, index) => {
-    const newMonth =
-      whichMonthsToRender === 'prev'
-        ? subMonths(startDate, numberOfMonths - 1 - index)
-        : addMonths(startDate, index);
+  whichMonthsToRender?: 'prev' | 'next',
+  renderFirstMonthFrom: Date,
+}): Array<MonthDateType> =>
+  new Array(Math.abs(numberOfRenderedMonths))
+    .fill(undefined)
+    .map((_, index) => {
+      const newMonth =
+        whichMonthsToRender === 'prev'
+          ? subMonths(renderFirstMonthFrom, numberOfRenderedMonths - 1 - index)
+          : addMonths(renderFirstMonthFrom, index);
 
-    return {
-      month: getMonth(newMonth),
-      year: getYear(newMonth),
-      numberOfWeeks: getWeeksInMonth(newMonth, { weekStartsOn: weekStartsOn }),
-    };
-  });
+      return {
+        month: getMonth(newMonth),
+        year: getYear(newMonth),
+        numberOfWeeks: getWeeksInMonth(newMonth, { weekStartsOn }),
+      };
+    });
 
 export const isDayInPast = (checkedDay: ?Date) =>
   checkedDay && isBefore(checkedDay, new Date());
@@ -104,13 +111,15 @@ export const generateNeighbourhood = (
 ) => {
   // @TODO Optimise this function to not generate neighbourhood every time
   const isDraggingUp = fingerRelativePosition.y < 0;
-  const whichMonthsToRender = isDraggingUp ? 'prev' : 'next';
-  const neighbourhood = getMonths(
-    howManyMonthsToRender(fingerRelativePosition.y, dayItemSize),
+  const neighbourhood = getMonths({
+    numberOfRenderedMonths: howManyMonthsToRender(
+      fingerRelativePosition.y,
+      dayItemSize,
+    ),
     weekStartsOn,
-    whichMonthsToRender,
-    grabbedStartDay,
-  ).map<AnotatedMonthType>(item => ({
+    whichMonthsToRender: isDraggingUp ? 'prev' : 'next',
+    renderFirstMonthFrom: grabbedStartDay,
+  }).map<AnotatedMonthType>(item => ({
     year: item.year,
     month: item.month,
     numberOfWeeks: item.numberOfWeeks,
@@ -222,6 +231,7 @@ export const findRelatedItem = (
     dayItemSize,
     grabbedSide,
     weekStartsOn,
+    isChoosingPastDatesEnabled,
   } = config;
 
   const touchBuffer = getTouchBuffer(dayItemSize.height);
@@ -279,7 +289,7 @@ export const findRelatedItem = (
 
           if (
             !isEqual(selectedDates, newSelectedDate) &&
-            !isDayInPast(newDateWithXYShift) &&
+            (!isDayInPast(newDateWithXYShift) || isChoosingPastDatesEnabled) &&
             (isBefore(newSelectedDate[0], newSelectedDate[1]) ||
               isSameDay(newSelectedDate[0], newSelectedDate[1]))
           ) {


### PR DESCRIPTION
- RangeDatePicker can be rendered from desired date (not only from today) by `renderFirstMonthFrom` props
- it's possible to use prop `isChoosingPastDatesEnabled` to enable selecting dates in history

Closes #828 