### PR TITLE
Fix: Location field can be null (for instance, in a region)

### DIFF
--- a/apps/graphql/src/apps/location/Location.js
+++ b/apps/graphql/src/apps/location/Location.js
@@ -46,7 +46,7 @@ export type ApiLocation = {|
     ...ApiLocationArea,
     +country: ?ApiLocationArea,
   },
-  +location: {|
+  +location?: {|
     +lat: number,
     +lon: number,
   |},

--- a/apps/graphql/src/apps/location/helpers/sanitizeLocation.js
+++ b/apps/graphql/src/apps/location/helpers/sanitizeLocation.js
@@ -25,8 +25,8 @@ export default function sanitizeLocation(location: ApiLocation) {
     type: location.type,
     timezone: location.timezone,
     coordinates: {
-      lat: location.location.lat,
-      lng: location.location.lon,
+      lat: location.location?.lat,
+      lng: location.location?.lon,
     },
     country: {
       id: location.city?.country?.id ?? '',


### PR DESCRIPTION
The search failed when it contained a region because the Tequila response didn't contain a `location` field with a latitude, etc... so adding the null check there does the trick

Closes #824.

