### PR TITLE
Refactor the SearchContext

### DIFF
--- a/apps/core/contexts/bookingContext/BookingContext.js
+++ b/apps/core/contexts/bookingContext/BookingContext.js
@@ -23,20 +23,16 @@ export type PassengerType = {|
 |};
 
 type State = {|
-  bookingToken: ?string,
   passengers: Array<PassengerType>,
   actions: {|
     setPassengers: (Array<PassengerType>) => void,
-    setBookingToken: string => void,
   |},
 |};
 
 const defaultState = {
   passengers: [],
-  bookingToken: undefined,
   actions: {
     setPassengers: noop,
-    setBookingToken: noop,
   },
 };
 
@@ -53,14 +49,9 @@ export default class BookingContextProvider extends React.Component<
       ...defaultState,
       actions: {
         setPassengers: this.setPassengers,
-        setBookingToken: this.setBookingToken,
       },
     };
   }
-
-  setBookingToken = (bookingToken: string) => {
-    this.setState({ bookingToken });
-  };
 
   setPassengers = (passengers: Array<PassengerType>) => {
     this.setState({ passengers });

--- a/apps/core/contexts/searchContext/SearchContext.js
+++ b/apps/core/contexts/searchContext/SearchContext.js
@@ -15,6 +15,7 @@ import qs from 'qs';
 
 type Props = {|
   +children: React.Node,
+  +routerQuery?: ParseFieldsParams,
 |};
 
 type ParseFieldsParams = {|
@@ -88,7 +89,6 @@ type State = {|
     +clearLocation: LocationSearchType => void,
     +addLocation: (type: LocationSearchType, location: Location) => void,
     +setLocation: (type: LocationSearchType, location: Location) => void,
-    +setStateFromQueryParams: ParseFieldsParams => void,
     +setBookingToken: string => void,
   },
 |};
@@ -144,7 +144,6 @@ const defaultState = {
     setLocation: noop,
     clearLocation: noop,
     addLocation: noop,
-    setStateFromQueryParams: noop,
     setBookingToken: noop,
   },
 };
@@ -165,8 +164,12 @@ export default class SearchContextProvider extends React.Component<
 > {
   constructor(props: Props) {
     super(props);
+
+    const { routerQuery } = props;
+
     this.state = {
       ...defaultState,
+      ...(routerQuery && this.parseFields(routerQuery)), // hydrate state from URL for the web
       actions: {
         switchFromTo: this.switchFromTo,
         setDepartureDate: this.setDepartureDate,
@@ -179,7 +182,6 @@ export default class SearchContextProvider extends React.Component<
         clearLocation: this.clearLocation,
         addLocation: this.addLocation,
         setLocation: this.setLocation,
-        setStateFromQueryParams: this.setStateFromQueryParams,
         setBookingToken: this.setBookingToken,
       },
     };
@@ -189,6 +191,7 @@ export default class SearchContextProvider extends React.Component<
     this.setState({ bookingToken });
   };
 
+  // @TODO moved to SerchContext helpers and write tests
   parseFields = (params: ParseFieldsParams): ParseFieldsReturn => {
     return {
       ...parseDate(params.dateFrom, 'dateFrom'),
@@ -218,6 +221,7 @@ export default class SearchContextProvider extends React.Component<
     });
   };
 
+  // @TODO moved to SerchContext helpers and write tests
   parseLocationParam = (param: ?string): $ReadOnlyArray<Location> | null => {
     if (param == null) {
       return null;
@@ -227,18 +231,6 @@ export default class SearchContextProvider extends React.Component<
       key => asObject[key],
     );
     return asLocationArray;
-  };
-
-  setStateFromQueryParams = (params: ParseFieldsParams) => {
-    const parsedParams: ParseFieldsParams = qs.parse(params);
-
-    const travelFrom = this.parseLocationParam(parsedParams.travelFrom);
-    const travelTo = this.parseLocationParam(parsedParams.travelTo);
-    this.setState({
-      ...this.parseFields(parsedParams),
-      ...(travelFrom ? { travelFrom } : {}),
-      ...(travelTo ? { travelTo } : {}),
-    });
   };
 
   setDepartureDate = (dateFrom: Date, dateTo: Date) => {

--- a/apps/core/contexts/searchContext/SearchContext.js
+++ b/apps/core/contexts/searchContext/SearchContext.js
@@ -28,6 +28,7 @@ type ParseFieldsParams = {|
   +infants?: ?string,
   +travelFrom?: ?string,
   +travelTo?: ?string,
+  +bookingToken: ?string,
 |};
 
 type ParseFieldsReturn = {|
@@ -39,6 +40,7 @@ type ParseFieldsReturn = {|
   +nightsInDestinationTo?: number,
   +adults?: number,
   +infants?: number,
+  +bookingToken: ?string,
 |};
 
 export type PassengersData = {|
@@ -67,6 +69,7 @@ type StateParams = {|
   dateTo: Date,
   returnDateFrom: Date,
   returnDateTo: Date,
+  bookingToken: ?string,
   ...PassengersData,
 |};
 
@@ -85,12 +88,14 @@ type State = {|
     +clearLocation: LocationSearchType => void,
     +addLocation: (type: LocationSearchType, location: Location) => void,
     +setLocation: (type: LocationSearchType, location: Location) => void,
-    +setStateFromQueryParams: Object => void,
+    +setStateFromQueryParams: ParseFieldsParams => void,
+    +setBookingToken: string => void,
   },
 |};
 
 const defaultDepartureDate = DateFNS.addDays(new Date(), 1);
 const defaultReturnDate = DateFNS.addDays(defaultDepartureDate, 2);
+
 // TODO Temporary values for better development experiences, It should be replaced with nearest place suggestion.
 const defaultPlaces = {
   origin: [
@@ -124,6 +129,7 @@ const defaultState = {
   limit: SEARCH_RESULTS_LIMIT,
   returnDateFrom: defaultReturnDate,
   returnDateTo: defaultReturnDate,
+  bookingToken: null,
   adults: 1,
   infants: 0,
   actions: {
@@ -139,6 +145,7 @@ const defaultState = {
     clearLocation: noop,
     addLocation: noop,
     setStateFromQueryParams: noop,
+    setBookingToken: noop,
   },
 };
 
@@ -173,9 +180,14 @@ export default class SearchContextProvider extends React.Component<
         addLocation: this.addLocation,
         setLocation: this.setLocation,
         setStateFromQueryParams: this.setStateFromQueryParams,
+        setBookingToken: this.setBookingToken,
       },
     };
   }
+
+  setBookingToken = (bookingToken: string) => {
+    this.setState({ bookingToken });
+  };
 
   parseFields = (params: ParseFieldsParams): ParseFieldsReturn => {
     return {
@@ -191,6 +203,7 @@ export default class SearchContextProvider extends React.Component<
       ...(params.nightsInDestinationTo
         ? { nightsInDestinationTo: params.nightsInDestinationTo }
         : {}),
+      ...(params.bookingToken ? { bookingToken: params.bookingToken } : {}),
     };
   };
 

--- a/apps/core/scenes/resultDetail/ResultDetail.js
+++ b/apps/core/scenes/resultDetail/ResultDetail.js
@@ -19,11 +19,9 @@ type Props = {|
   +adults: number,
   +infants: number,
   +bookingToken: string,
-  +bookingContext: {|
+  +context: {|
     +bookingToken: ?string,
     +setBookingToken: string => void,
-  |},
-  +searchContext: {|
     +adults: number,
     +infants: number,
     +setPassengerData: PassengersData => void,
@@ -32,32 +30,26 @@ type Props = {|
 
 class ResultDetail extends React.Component<Props> {
   componentDidMount() {
-    const {
-      bookingToken,
-      adults,
-      infants,
-      searchContext,
-      bookingContext,
-    } = this.props;
+    const { bookingToken, adults, infants, context } = this.props;
 
-    bookingContext.setBookingToken(bookingToken);
+    context.setBookingToken(bookingToken);
 
     // set the SearchContext state if it is not
-    if (searchContext.adults !== adults && searchContext.infants !== infants) {
-      searchContext.setPassengerData({ adults, infants });
+    if (context.adults !== adults && context.infants !== infants) {
+      context.setPassengerData({ adults, infants });
     }
   }
 
   renderInner = (data: ResultDetailQueryResponse) => {
-    const { bookingContext, searchContext } = this.props;
+    const { context } = this.props;
     const passengers = {
-      infants: searchContext.infants,
-      adults: searchContext.adults,
+      infants: context.infants,
+      adults: context.adults,
     };
     return (
       <ResultDetailInner
         data={data}
-        bookingToken={bookingContext.bookingToken}
+        bookingToken={context.bookingToken}
         passengers={passengers}
       />
     );
@@ -85,27 +77,18 @@ class ResultDetail extends React.Component<Props> {
   }
 }
 
-const bookingContextState = ({
-  actions: { setBookingToken },
-  bookingToken,
-}: BookingContextState) => ({
-  bookingContext: {
-    bookingToken,
-    setBookingToken,
-  },
-});
-
 const selectSearchContextState = ({
-  actions: { setPassengerData },
+  actions: { setPassengerData, setBookingToken },
   infants,
   adults,
+  bookingToken,
 }: SearchContextState) => ({
-  searchContext: {
+  context: {
     infants,
     adults,
     setPassengerData,
+    setBookingToken,
+    bookingToken,
   },
 });
-export default withSearchContext(selectSearchContextState)(
-  withBookingContext(bookingContextState)(ResultDetail),
-);
+export default withSearchContext(selectSearchContextState)(ResultDetail);

--- a/apps/core/scenes/resultDetail/ResultDetail.js
+++ b/apps/core/scenes/resultDetail/ResultDetail.js
@@ -6,10 +6,6 @@ import { QueryRenderer, graphql } from '@kiwicom/margarita-relay';
 import type { ResultDetailQueryResponse } from './__generated__/ResultDetailQuery.graphql';
 import ResultDetailInner from './ResultDetailInner';
 import {
-  withBookingContext,
-  type BookingContextState,
-} from '../../contexts/bookingContext/BookingContext';
-import {
   withSearchContext,
   type SearchContextState,
   type PassengersData,

--- a/apps/core/scenes/results/Results.js
+++ b/apps/core/scenes/results/Results.js
@@ -36,7 +36,6 @@ import {
   type Location,
 } from '../../contexts/searchContext/SearchContext';
 import SortTabsWrapper from '../search/SortTabsWrapper';
-import { type SearchParameters } from '../search/Search';
 
 type Props = {|
   +navigation: Navigation,
@@ -56,16 +55,9 @@ type Props = {|
   +nightsInDestinationFrom: string,
   +nightsInDestinationTo: string,
   +isNightsInDestinationSelected: boolean,
-  +routerQuery: SearchParameters,
-  +setStateFromQueryParams: SearchParameters => void,
 |};
 
 class Results extends React.Component<Props> {
-  componentDidMount() {
-    const { setStateFromQueryParams, routerQuery } = this.props;
-    setStateFromQueryParams(routerQuery);
-  }
-
   handleBookPress = (bookingToken: ?string) => {
     const { adults, infants } = this.props;
     this.props.navigation.navigate(Routes.RESULT_DETAIL, {
@@ -264,7 +256,6 @@ const select = ({
   nightsInDestinationFrom,
   nightsInDestinationTo,
   isNightsInDestinationSelected,
-  actions: { setStateFromQueryParams },
 }: SearchContextState) => ({
   travelFrom,
   travelTo,
@@ -280,7 +271,6 @@ const select = ({
   nightsInDestinationFrom,
   nightsInDestinationTo,
   isNightsInDestinationSelected,
-  setStateFromQueryParams,
 });
 
 const layoutSelect = ({ layout }: LayoutContextState) => ({

--- a/apps/core/scenes/search/Search.js
+++ b/apps/core/scenes/search/Search.js
@@ -11,11 +11,7 @@ import {
   type LayoutContextState,
 } from '@kiwicom/margarita-device';
 
-import {
-  withSearchContext,
-  type Location,
-  type SearchContextState,
-} from '../../contexts/searchContext/SearchContext';
+import type { Location } from '../../contexts/searchContext/SearchContext';
 import SearchForm from '../../components/searchForm/SearchForm';
 
 export type SearchParameters = {|
@@ -38,16 +34,9 @@ export type SearchParameters = {|
 type Props = {|
   +layout: number,
   +onSubmit?: SearchParameters => void,
-  +routerQuery: SearchParameters,
-  +setStateFromQueryParams: SearchParameters => void,
 |};
 
 class Search extends React.Component<Props> {
-  componentDidMount() {
-    const { setStateFromQueryParams, routerQuery } = this.props;
-    setStateFromQueryParams(routerQuery);
-  }
-
   render() {
     const desktopLayout = this.props.layout >= LAYOUT.desktop;
 
@@ -118,12 +107,4 @@ const layoutSelect = ({ layout }: LayoutContextState) => ({
   layout,
 });
 
-const searchContextStateSelect = ({
-  actions: { setStateFromQueryParams },
-}: SearchContextState) => ({
-  setStateFromQueryParams,
-});
-
-export default withSearchContext(searchContextStateSelect)(
-  withLayoutContext(layoutSelect)(Search),
-);
+export default withLayoutContext(layoutSelect)(Search);

--- a/apps/web/pages/_app.js
+++ b/apps/web/pages/_app.js
@@ -12,13 +12,18 @@ import {
 
 export default class App extends NextApp {
   render() {
-    const { Component, pageProps } = this.props;
+    const {
+      Component,
+      pageProps,
+      router: { query: routerQuery },
+    } = this.props;
+
     return (
       <Container>
         <UserContextProvider>
           <BookingContextProvider>
             <AlertContextProvider>
-              <SearchContextProvider>
+              <SearchContextProvider routerQuery={routerQuery}>
                 <LayoutContextProvider>
                   <Component {...pageProps} />
                 </LayoutContextProvider>


### PR DESCRIPTION
**Summary**
- Hydrate the SearchContext from the URL at context creation
- Removed the `setStateFromQueryParams` from components `componentDidMount`, because it shouldn't be necessary.
- Moved the BookingToken from BookingContext to SearchContext, for code simplicity
(need to rethink if the `BookingContext` is necessary)

__________________________________________________________________________________
**Plan for next PRs**
- Move the SearchContexts parser methods to helper file, and write tests.
- Render empty PassengerCards based on count of passengers from SearchContex, similar behavior like on kiwi.com