### PR TITLE
Docs: Demo links

### DIFF
--- a/docs/apps/graphql/index.md
+++ b/docs/apps/graphql/index.md
@@ -3,6 +3,13 @@ title: GraphQL Server
 sidebar_label: GraphQL Server
 ---
 
+## Explore deployed version
+
+- 🎮 [GraphQL Playground](https://p2kwd3i3a8.execute-api.eu-central-1.amazonaws.com/staging/graphql)
+- 🚀 [GraphQL Voyager](https://margarita-graphql-voyager.now.sh/)
+
+## Running server locally
+
 _Check the [instructions](../../getting-started) to have the project correctly set up first_.
 
 From the root of `margarita`, run

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -3,8 +3,14 @@ title: Where can I see the web and mobile demos?
 sidebar_label: Web and Mobile demos
 ---
 
-_This page is a stub._
+## Web
+* Deployed version: **https://kiwicom-margarita.netlify.com**
+* More info in separate [Web section](./apps/web/)
 
-- 🕸️ Web version: https://kiwicom-margarita.netlify.com
-- 🎮 GraphQL Playground https://p2kwd3i3a8.execute-api.eu-central-1.amazonaws.com/staging/graphql
-- 🚀 GraphQL Voyager: https://margarita-graphql-voyager.now.sh/
+
+## Mobile
+* Project in Expo: **https://expo.io/@kiwicom-margarita-public/margarita-mobile**
+* More info [Mobile section](./apps/mobile/)
+
+
+


### PR DESCRIPTION
Removed stub text from demo section. 
Kept just two relevant demo links and moved remaining GraphQL related ones to `GraphQL Server` section.

Closes #862 