### PR TITLE
Fix: Unified Modal styling between platforms

### DIFF
--- a/packages/universal-components/src/Modal/Modal.native.js
+++ b/packages/universal-components/src/Modal/Modal.native.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import ReactModal from 'react-native-modal';
 
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { Props } from './ModalTypes';
 
 /**
@@ -18,6 +19,7 @@ function Modal(props: Props) {
       useNativeDriver
       hideModalContentWhileAnimating // this is workaround for `useNativeDriver` property (see: https://github.com/react-native-community/react-native-modal#the-modal-flashes-in-a-weird-way-when-animating)
       {...props}
+      style={[styles.modal, props.style]}
     />
   );
 }
@@ -25,5 +27,11 @@ function Modal(props: Props) {
 Modal.defaultProps = {
   backdropOpacity: 0.5,
 };
+
+const styles = StyleSheet.create({
+  modal: {
+    margin: 0,
+  },
+});
 
 export default Modal;

--- a/packages/universal-components/src/Modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/universal-components/src/Modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -53,7 +53,7 @@ exports[`Modal - native should match snapshot 1`] = `
       Object {
         "flex": 1,
         "justifyContent": "center",
-        "margin": 37.5,
+        "margin": 0,
         "transform": Array [
           Object {
             "translateY": 0,

--- a/packages/universal-components/src/RangeDatePicker/RangeDatePicker.js
+++ b/packages/universal-components/src/RangeDatePicker/RangeDatePicker.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { View } from 'react-native';
+import { View, SafeAreaView } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Button } from '../Button';
@@ -73,7 +73,7 @@ export default class RangeDatePicker extends React.Component<Props> {
         onRequestClose={this.handleDismiss}
         onBackdropPress={this.handleDismiss}
       >
-        <View style={styles.content}>
+        <SafeAreaView style={styles.content}>
           {!isNightsInDestinationSelected || !isNightsInDestinationVisible ? (
             <RangeDatePickerContent
               isChoosingPastDatesEnabled={isChoosingPastDatesEnabled ?? false}
@@ -123,7 +123,7 @@ export default class RangeDatePicker extends React.Component<Props> {
               </View>
             </View>
           </View>
-        </View>
+        </SafeAreaView>
       </Modal>
     );
   }
@@ -154,6 +154,10 @@ const styles = StyleSheet.create({
   },
   buttonWrapper: {
     flex: 1,
+    ios: {
+      // @TODO bottom margin needs to be currently set for iOS because of the persisting bug related to `SafeAreaView` and `Modal` on iPhone X https://github.com/facebook/react-native/issues/18177
+      marginBottom: parseFloat(defaultTokens.spaceMedium),
+    },
   },
   confirmButton: {
     marginStart: parseFloat(defaultTokens.spaceXSmall),


### PR DESCRIPTION
Removed default Modal margin in native version to make styling consistent across platforms.
Updated RangeDatePicker to fit modal content into view.

Closes #841

<img width="398" alt="Screenshot 2019-06-03 at 14 58 53" src="https://user-images.githubusercontent.com/2660330/58804014-18ca7c00-8611-11e9-94f9-07f088cbac7e.png">